### PR TITLE
Control character escapes should not be recursive; otherwise you comp…

### DIFF
--- a/tockloader/bootloader_serial.py
+++ b/tockloader/bootloader_serial.py
@@ -379,14 +379,11 @@ class BootloaderSerial(BoardInterface):
 		ret = self.sp.read(2 + response_len)
 
 		# Response is escaped, so we need to handle that
-		while True:
-			num_escaped = ret.count(bytes([self.ESCAPE_CHAR, self.ESCAPE_CHAR]))
-			if num_escaped > 0:
-				# De-escape, and then read in the missing characters.
-				ret = ret.replace(bytes([self.ESCAPE_CHAR, self.ESCAPE_CHAR]), bytes([self.ESCAPE_CHAR]))
-				ret += self.sp.read(num_escaped)
-			else:
-				break
+		num_escaped = ret.count(bytes([self.ESCAPE_CHAR, self.ESCAPE_CHAR]))
+		if num_escaped > 0:
+			# De-escape, and then read in the missing characters.
+			ret = ret.replace(bytes([self.ESCAPE_CHAR, self.ESCAPE_CHAR]), bytes([self.ESCAPE_CHAR]))
+			ret += self.sp.read(num_escaped)
 
 		if len(ret) < 2:
 			if show_errors:


### PR DESCRIPTION
otherwise you compress any run of escape characters into a single one (which is incorrect).

E.g., with the old code, the sequence

0xfc 0xfc 0xfc 0xfc
  becomes
0xfc

  when it should become
0xfc 0xfc