### PR TITLE
Fix a bug in UTF decoding if no bootloader present

### DIFF
--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -493,7 +493,7 @@ class TockLoader:
 		address = 0x400
 		length = 14
 		flag = self.channel.read_range(address, length)
-		flag_str = flag.decode('utf-8')
+		flag_str = flag.decode('utf-8', 'ignore')
 		if self.args.debug:
 			print('Read from flags location: {}'.format(flag_str))
 		return flag_str == 'TOCKBOOTLOADER'


### PR DESCRIPTION
Checking for a bootloader tries to decode the UTF-8 string
"TOCKBOOTLOADER" at a particular address. However, if this address
doesn't contain a bootloader, it _may_ contain a non-UTF8 decodable
byte.

We've been using implicit 'strict' error handling for the UTF package,
which throws an exception.  This change simply changes that to 'ignore'.