### PR TITLE
Provide more options for JLinkExe (and add JLink support for Launchxl

### DIFF
--- a/tockloader/board_interface.py
+++ b/tockloader/board_interface.py
@@ -19,6 +19,8 @@ class BoardInterface:
 		            'openocd': 'nordic_nrf52_dk.cfg'},
 		'launchxl-cc26x2r1': {'arch': 'cortex-m4',
 		                      'page_size': 512,
+                                      'jlink_device': 'cc13x2r1f3',
+                                      'jlink_speed': 4000,
 		                      'openocd': 'ti_cc26x2_launchpad.cfg',
 		                      'openocd_options': ['noreset']},
 		'ek-tm4c1294xl': {'arch': 'cortex-m4',
@@ -37,6 +39,8 @@ class BoardInterface:
 		self.board = getattr(self.args, 'board', None)
 		self.arch = getattr(self.args, 'arch', None)
 		self.jlink_device = getattr(self.args, 'jlink_device', None)
+		self.jlink_speed = getattr(self.args, 'jlink_speed', 1200)
+		self.jlink_if = getattr(self.args, 'jlink_if', 'swd')
 		self.openocd_board = getattr(self.args, 'openocd_board', None)
 		self.openocd_options = getattr(self.args, 'openocd_options', [])
 		self.page_size = getattr(self.args, 'page_size', 0)

--- a/tockloader/jlinkexe.py
+++ b/tockloader/jlinkexe.py
@@ -48,7 +48,7 @@ class JLinkExe(BoardInterface):
 
 			jlink_file.flush()
 
-			jlink_command = 'JLinkExe -device {} -if swd -speed 1200 -AutoConnect 1 {}'.format(self.jlink_device, jlink_file.name)
+			jlink_command = 'JLinkExe -device {} -if {} -speed {} -AutoConnect 1 -jtagconf -1,-1 {}'.format(self.jlink_device, self.jlink_if, self.jlink_speed, jlink_file.name)
 
 			if self.args.debug:
 				print('Running "{}".'.format(jlink_command))


### PR DESCRIPTION
Currently using JLink assumes particular modes of communication, specifically SWD @ 1200MHz, but not all chips/boards adhere to that (the Launchxl being a notable exception).

This change just parameterizes those options and adds support for using JLink for the Launchxl board.