### PR TITLE
Reset LaunchXL

### DIFF
--- a/tockloader/board_interface.py
+++ b/tockloader/board_interface.py
@@ -23,7 +23,7 @@ class BoardInterface:
 		                      'jlink_speed': 4000,
 		                      'jlink_if': 'jtag',
 		                      'openocd': 'ti_cc26x2_launchpad.cfg',
-		                      'openocd_options': ['noreset']},
+		                      'openocd_options': ['noreset', 'resume']},
 		'ek-tm4c1294xl': {'arch': 'cortex-m4',
 		                  'page_size': 512,
 		                  'openocd': 'ek-tm4c1294xl.cfg'},

--- a/tockloader/openocd.py
+++ b/tockloader/openocd.py
@@ -42,8 +42,10 @@ class OpenOCD(BoardInterface):
 		prefix = 'set WORKAREASIZE 0; ' if 'workareazero' in self.openocd_options else ''
 		cmd_prefix = 'init; halt;' if 'noreset' in self.openocd_options else 'init; reset init; halt;'
 
-		openocd_command = 'openocd -c "{prefix}source [find board/{board}]; {cmd_prefix} {cmd} exit"'.format(
-			board=self.openocd_board, cmd=commands, prefix=prefix, cmd_prefix=cmd_prefix)
+		cmd_suffix = 'soft_reset_halt; resume;' if 'resume' else ''
+
+		openocd_command = 'openocd -c "{prefix}source [find board/{board}]; {cmd_prefix} {cmd} {cmd_suffix} exit"'.format(
+			board=self.openocd_board, cmd=commands, prefix=prefix, cmd_prefix=cmd_prefix, cmd_suffix=cmd_suffix)
 
 		if self.args.debug:
 			print('Running "{}".'.format(openocd_command))


### PR DESCRIPTION
I added in a new "openocd_option" that would allow the launchXL (XDS110-based) launch the app after upload.

Also, when I was trying to get tockloader working on Windows, `import fnctl` was causing issues but did not appear to be used, so I removed it.