### PR TITLE
Windows OpenOCD compatible

### DIFF
--- a/tockloader/bootloader_serial.py
+++ b/tockloader/bootloader_serial.py
@@ -6,15 +6,22 @@ Interface with a board over serial that is using the
 import atexit
 import crcmod
 import datetime
-import fcntl
 import hashlib
 import json
 import os
+import platform
 import socket
 import struct
 import sys
 import time
 import threading
+
+'''
+Although Windows is not supported actively, this allow features that "just work" to work
+'''
+if platform.system() != 'Windows':
+	import fcntl
+
 
 import serial
 import serial.tools.list_ports

--- a/tockloader/openocd.py
+++ b/tockloader/openocd.py
@@ -8,6 +8,7 @@ way. Note, I just made up the string (flag) names; they are not passed to
 OpenOCD directly.
 '''
 
+import platform
 import shlex
 import subprocess
 import tempfile
@@ -34,8 +35,11 @@ class OpenOCD(BoardInterface):
 				temp_bin.write(binary)
 
 			temp_bin.flush()
-			# For Windows, forward slashes need to be escaped
-			temp_bin = temp_bin.name.replace('\\', '\\\\'))
+
+			if platform.system() == 'Windows':
+				# For Windows, forward slashes need to be escaped
+				temp_bin = temp_bin.name.replace('\\', '\\\\')
+
 			# Update the command with the name of the binary file
 			commands = commands.format(binary=temp_bin.name)
 

--- a/tockloader/openocd.py
+++ b/tockloader/openocd.py
@@ -34,7 +34,8 @@ class OpenOCD(BoardInterface):
 				temp_bin.write(binary)
 
 			temp_bin.flush()
-
+			# For Windows, forward slashes need to be escaped
+			temp_bin = temp_bin.name.replace('\\', '\\\\'))
 			# Update the command with the name of the binary file
 			commands = commands.format(binary=temp_bin.name)
 


### PR DESCRIPTION
I'd like to apologize upfront because this isn't very pretty. But basically, I'm preparing for a workshop where some users might have Windows and I'm trying to get some basic functionality out of Tockloader to support that. In particular, our board has the XDS110 on it which works via OpenOCD.

So what I've done here is made Tockloader work for OpenOCD. Where it's not pretty is the fnctl conditional import in `bootloader_serial.py`. I'm not sure if you can suggest a cleaner way to do this other than taking the time to make that feature work on both platforms... which isn't an option on my end at the moment, unfortunately.