### PR TITLE
Windows delete file fix and proper amount of slash escaping

### DIFF
--- a/tockloader/openocd.py
+++ b/tockloader/openocd.py
@@ -16,7 +16,11 @@ import tempfile
 from .board_interface import BoardInterface
 from .exceptions import TockLoaderException
 
+# global static variable for collecting temp files for Windows
+collect_temp_files = []
+
 class OpenOCD(BoardInterface):
+
 	def _run_openocd_commands (self, commands, binary, write=True):
 		'''
 		- `commands`: String of openocd commands. Use {binary} for where the name
@@ -25,7 +29,9 @@ class OpenOCD(BoardInterface):
 		- `write`: Set to true if the command writes binaries to the board. Set
 		  to false if the command will read bits from the board.
 		'''
-		delete = True
+
+		# in Windows, you can't mark delete bc they delete too fast
+		delete = platform.system() != 'Windows'
 		if self.args.debug:
 			delete = False
 
@@ -38,7 +44,10 @@ class OpenOCD(BoardInterface):
 
 			if platform.system() == 'Windows':
 				# For Windows, forward slashes need to be escaped
-				temp_bin = temp_bin.name.replace('\\', '\\\\')
+				temp_bin.name = temp_bin.name.replace('\\', '\\\\\\')
+				# For Windows, files need to be manually deleted
+				global collect_temp_files
+				collect_temp_files += [temp_bin.name]
 
 			# Update the command with the name of the binary file
 			commands = commands.format(binary=temp_bin.name)

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -8,6 +8,8 @@ channel specific code is in other files.
 import binascii
 import contextlib
 import copy
+import os
+import platform
 import string
 import textwrap
 import time
@@ -18,7 +20,7 @@ from .bootloader_serial import BootloaderSerial
 from .exceptions import TockLoaderException
 from .tbfh import TBFHeader
 from .jlinkexe import JLinkExe
-from .openocd import OpenOCD
+from .openocd import OpenOCD, collect_temp_files
 
 class TockLoader:
 	'''
@@ -468,6 +470,11 @@ class TockLoader:
 			self.channel.determine_current_board()
 
 			yield
+
+			if platform.system() == 'Windows':
+				for file in collect_temp_files:
+					os.remove(file)
+
 
 			now = time.time()
 			print('Finished in {:0.3f} seconds'.format(now-then))


### PR DESCRIPTION
Apologies, but apparently my initial Windows PR did not actually work :-1: 

But I fixed it now, I promise!

And brought along one more hideous Windows complication [around temp files](https://stackoverflow.com/questions/15169101/how-to-create-a-temporary-file-that-can-be-read-by-a-subprocess).

I wish that I could manually delete the file before returning from `_run_openocd_commands` but when I did that, I was hit with a Windows Error telling me that I was deleting a file that someone was using still! Strange because I'm pretty sure subprocess.run() blocks until the subprocess has returned. So who is touching the file??

Alas, I do not know. So I collected the files and deleted them at the last possible moment in tockloader.py. Ugly AF but I don't have time or desire to understand how Windows works.

Happy for suggestions for more elegant fixes, but this works and is tested and should not affect behavior on other platforms. Apologies again for the intially broken PR; poor form on my behalf.

As a consolation, I can offer Windows setup instructions that for the libtock-c if you think that's at all a good idea to start advertising any Windows compatibility.