### PR TITLE
Windows communication setup

### DIFF
--- a/docs/bootloader_serial.md
+++ b/docs/bootloader_serial.md
@@ -270,6 +270,15 @@ Compares the CRC of the local binary to the one calculated by the
 bootloader.
 
 
+### \_configure\_socket
+```py
+
+def _configure_socket(self)
+
+```
+
+
+
 ### \_decode\_attribute
 ```py
 


### PR DESCRIPTION
Until now the program crashes every time a windows
user wants to try the program (like: `tockloader info`).

The reason: Python for Windows does not support AF_UNIX
as socket type. To communicate one could use AF_INET
but have to configure it differently.

This commit aims to provide more functionality to
windows users while not breaking unix support!