### PR TITLE
Fix JLinkExe for windows and JLink v6.60f...

### DIFF
--- a/tockloader/jlinkexe.py
+++ b/tockloader/jlinkexe.py
@@ -93,6 +93,7 @@ class JLinkExe(BoardInterface):
 					return temp_bin.read()
 		finally:
 			os.remove(jlink_file.name)
+			os.remove(temp_bin.name)
 
 	def flash_binary (self, address, binary):
 		'''


### PR DESCRIPTION
- Detect when Windows is the platform and call "JLink" command rather than "JLinkExe" as it is on other platforms
- Close temp files before expecting JLink to read/write them (to deal with windows file locking)
- Use the `-CommanderScript` switch when passing the JLink command file as per [the segger docs](https://wiki.segger.com/J-Link_Commander)

This is **not tested on Linux** (yet).