### PR TITLE
Add a command line argument (`--openocd-cmd`) to allow callers to control what OpenOCD binary tockloader will invoke.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,11 @@ everything to work. On MacOS you can use `brew install --HEAD openocd` to get
 a version from git.
 
     tockloader [command] --openocd --arch [arch] --board [board] --openocd-board [openocd_board] \
-    --openocd-options [openocd_options] --openocd-commands [openocd_commands]
+    --openocd-cmd [openocd_cmd] --openocd-options [openocd_options] \
+    --openocd-commands [openocd_commands]
 
 - `openocd_board`: The `.cfg` file in the board folder in OpenOCD to use.
+- `openocd_cmd`: The OpenOCD executable to invoke. Defaults to `openocd`.
 - `openocd_options`: A list of Tock-specific flags used to customize how
   Tockloader calls OpenOCD based on experience with various boards and their
   quirks. Options include:

--- a/tockloader/board_interface.py
+++ b/tockloader/board_interface.py
@@ -93,6 +93,7 @@ class BoardInterface:
 		self.jlink_speed = getattr(self.args, 'jlink_speed', None)
 		self.jlink_if = getattr(self.args, 'jlink_if', None)
 		self.openocd_board = getattr(self.args, 'openocd_board', None)
+		self.openocd_cmd = getattr(self.args, 'openocd_cmd', 'openocd')
 		self.openocd_options = getattr(self.args, 'openocd_options', [])
 		self.openocd_prefix = getattr(self.args, 'openocd_prefix', '')
 		self.openocd_commands = getattr(self.args, 'openocd_commands', {})

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -374,6 +374,9 @@ def main ():
 	parent_jtag.add_argument('--openocd-board',
 		default=None,
 		help='The cfg file in OpenOCD `board` folder.')
+	parent_jtag.add_argument('--openocd-cmd',
+		default='openocd',
+		help='The openocd binary to invoke.')
 	parent_jtag.add_argument('--openocd-options',
 		default=[],
 		help='Tockloader-specific flags to direct how Tockloader uses OpenOCD.',

--- a/tockloader/openocd.py
+++ b/tockloader/openocd.py
@@ -76,8 +76,9 @@ class OpenOCD(BoardInterface):
 		if 'resume' in self.openocd_options:
 			cmd_suffix = 'soft_reset_halt; resume;'
 
-		openocd_command = 'openocd -c "{prefix} {source} {cmd_prefix} {cmd} {cmd_suffix} exit"'.format(
-			prefix=prefix, source=source, cmd_prefix=cmd_prefix, cmd=commands, cmd_suffix=cmd_suffix)
+		openocd_command = '{openocd_cmd} -c "{prefix} {source} {cmd_prefix} {cmd} {cmd_suffix} exit"'.format(
+			openocd_cmd=self.openocd_cmd, prefix=prefix, source=source,
+			cmd_prefix=cmd_prefix, cmd=commands, cmd_suffix=cmd_suffix)
 
 		if self.args.debug:
 			logging.debug('Running "{}".'.format(openocd_command))


### PR DESCRIPTION
Some boards (such as the nrf52840dk) can only be programmed by recent versions of OpenOCD. This change allows users to install a newer OpenOCD version locally (rather than system-wide) and use that OpenOCD version with tockloader.

Example invocation: `tockloader flash --address 0x00000 --openocd --openocd-cmd "$HOME/openocd/install/bin/openocd" --board nrf52dk target/thumbv7em-none-eabi/release/nrf52840dk.bin`

Open questions for reviewers:

1. Should this be its own flag (current implementation) or a parameter inside openocd_options?
2. Should I try to provide this for JLinkExe as well? I don't have a copy of JLinkExe to test with.