### PR TITLE
print progress bar when flashing binary to board

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,6 @@ setup(name='tockloader',
           "crcmod >= 1.7",
           "pyserial >= 3.0.1",
           "pytoml >= 0.1.11",
+          "tqdm >= 4.45.0 ",
           ],
      )

--- a/tockloader/bootloader_serial.py
+++ b/tockloader/bootloader_serial.py
@@ -30,6 +30,8 @@ from . import helpers
 from .board_interface import BoardInterface
 from .exceptions import TockLoaderException
 
+from tqdm import tqdm 	# Used for printing progress bars
+
 class BootloaderSerial(BoardInterface):
 	'''
 	Implementation of `BoardInterface` for the Tock Bootloader over serial.
@@ -532,7 +534,7 @@ class BootloaderSerial(BoardInterface):
 
 		# Loop through the binary by pages at a time until it has been flashed
 		# to the chip.
-		for i in range(len(binary) // self.page_size):
+		for i in tqdm(range(len(binary) // self.page_size)):
 			# Create the packet that we send to the bootloader. First four
 			# bytes are the address of the page.
 			pkt = struct.pack('<I', address + (i*self.page_size))


### PR DESCRIPTION
Initial effort for issue #40 .

\# of Ticks in the progress bar equals the number of pages being written to device.

Progress bar is only printed when flashing binary to device.

stdout example:
```
lonelyjoe@lonelyjoe-desktop:~/workspace/tockloader$ python3 -m tockloader.main install blink
[INFO   ] Could not find TAB named "blink" locally.

[0]     No
[1]     Yes

Would you like to check the online TAB repository for that app? [0] 1
[INFO   ] No device name specified. Using default name "tock".
[INFO   ] Using "/dev/ttyUSB0 - Hail IoT Module - TockOS".

[STATUS ] Installing app on the board...
100%|████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 15.25it/s]
[INFO   ] CRC check passed. Binaries successfully loaded.
[INFO   ] Finished in 2.769 seconds
```