### PR TITLE
add retries when connection fails

### DIFF
--- a/tockloader/bootloader_serial.py
+++ b/tockloader/bootloader_serial.py
@@ -304,7 +304,22 @@ class BootloaderSerial(BoardInterface):
 				self.server_event.wait()
 				logging.info('Resuming listening...')
 
-		self.sp.open()
+		# on ubuntu 20.04, sometimes connecting to the serial port fails the first several times. This
+		# attempts to address that.
+		num_exceptions = 0
+		while True:
+			try:
+				self.sp.open()
+				break
+			except Exception as e:
+				if num_exceptions > 15:
+					logging.info('failed to connect, is the board connected?')
+					raise e
+				logging.info('trying to connect...')
+				time.sleep(0.1)
+				num_exceptions += 1
+
+
 
 		# Do a delay if we are skipping the bootloader entry process (which
 		# would normally have a delay in it). We need to send a dummy message
@@ -504,7 +519,20 @@ class BootloaderSerial(BoardInterface):
 			logging.debug('  Using port {} for the bootloader'.format(port))
 
 		self._configure_serial_port(port)
-		self.sp.open()
+		# on ubuntu 20.04, sometimes connecting to the serial port fails the first several times. This
+		# attempts to address that.
+		num_exceptions = 0
+		while True:
+			try:
+				self.sp.open()
+				break
+			except Exception as e:
+				if num_exceptions > 15:
+					logging.info('failed to connect, is the board connected?')
+					raise e
+				logging.info('trying to connect...')
+				time.sleep(0.1)
+				num_exceptions += 1
 
 		# Board restarted into the bootloader (or at least a new serial port)
 		# and we re-setup self.sp to use it.


### PR DESCRIPTION
On Ubuntu 20.04 these 2 steps frequently fail for me, but catching the exceptions and trying again usually works.