### PR TITLE
Fix parsed JLinkExe error message

### DIFF
--- a/tockloader/jlinkexe.py
+++ b/tockloader/jlinkexe.py
@@ -175,7 +175,7 @@ class JLinkExe(BoardInterface):
 			stdout = p.stdout.decode('utf-8')
 			if 'USB...FAILED' in stdout:
 				raise TockLoaderException('ERROR: Cannot find JLink hardware. Is USB attached?')
-			if 'Can not connect to target.' in stdout:
+			if 'Can not connect to target.' in stdout or 'Cannot connect to target.' in stdout:
 				raise TockLoaderException('ERROR: Cannot find device. Is JTAG connected?')
 			if 'Error while programming flash' in stdout:
 				raise TockLoaderException('ERROR: Problem flashing.')


### PR DESCRIPTION
While debugging an nrf52480-dongle via JTAG I noticed that the JLinkExe always fails to connect but tockloader returns success while flashing. After a while I found out that tockloader parses the error message in a wrong way.

JLinkExe Version: SEGGER J-Link Commander V7.52a (Compiled Jul 28 2021 11:08:16)