### PR TITLE
Minimum size apps of 4096 as default for the microbit

### DIFF
--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -75,6 +75,7 @@ class TockLoader:
 	                               'openocd': True}},
 	    'arty': {'size_minimum': 0x10000,
 	             'size_constraint': None},
+	    'microbit_v2': {'size_minimum': 4096},
 	}
 
 


### PR DESCRIPTION
Adds `minimum_size` of 4096 as a default command for the Microbit v2.

Tested on a Microbit v2 and resolves #67, which discusses tradeoffs.

Note: adding `bundle_apps' also resolves the problem.

_Edited: original version used `bundle_apps`_