### PR TITLE
Update microbit for openocd 0.11

### DIFF
--- a/tockloader/board_interface.py
+++ b/tockloader/board_interface.py
@@ -210,7 +210,7 @@ class BoardInterface:
                            source [find target/nrf52.cfg]; \
                            set WORKAREASIZE 0x40000; \
                            $_TARGETNAME configure -work-area-phys 0x20000000 -work-area-size $WORKAREASIZE -work-area-backup 0; \
-                           catch { flash bank $_CHIPNAME.flash nrf51 0x00000000 0 1 1 $_TARGETNAME; } err",
+                           catch { flash bank $_CHIPNAME.flash nrf51 0x00000000 0 1 1 $_TARGETNAME } err;",
             },
         },
     }

--- a/tockloader/board_interface.py
+++ b/tockloader/board_interface.py
@@ -210,7 +210,7 @@ class BoardInterface:
                            source [find target/nrf52.cfg]; \
                            set WORKAREASIZE 0x40000; \
                            $_TARGETNAME configure -work-area-phys 0x20000000 -work-area-size $WORKAREASIZE -work-area-backup 0; \
-                           flash bank $_CHIPNAME.flash nrf51 0x00000000 0 1 1 $_TARGETNAME;",
+                           catch { flash bank $_CHIPNAME.flash nrf51 0x00000000 0 1 1 $_TARGETNAME; } err",
             },
         },
     }


### PR DESCRIPTION
This pull request adds a `catch - err` to one of the openocd commands for the microbit.

The new openocd 0.11 that is shipped with Ubuntu 21.04 seems to already define the flash banks and fails. Adding a `catch err` makes tockloader work with the old version of openocd (0.10) and with the new version. Ubuntu 20.04 LTS still provides openocd 0.10.

