### PR TITLE
Add RTT support for OpenOCD

### DIFF
--- a/tockloader/board_interface.py
+++ b/tockloader/board_interface.py
@@ -256,9 +256,9 @@ class BoardInterface:
             "page_size": 4096,
             "no_attribute_table": True,
             "openocd": {
-                "prefix": 'source [find interface/stlink.cfg]; \
+                "prefix": "source [find interface/stlink.cfg]; \
                            interface hla; \
-                           source [find target/nrf52.cfg];',
+                           source [find target/nrf52.cfg];",
             },
         },
     }

--- a/tockloader/board_interface.py
+++ b/tockloader/board_interface.py
@@ -250,6 +250,17 @@ class BoardInterface:
                            source [find target/rp2040.cfg];",
             },
         },
+        "sma_q3": {
+            "description": "SMA Q3 smart watch (Bangle.js 2, Jazda)",
+            "arch": "cortex-m4",
+            "page_size": 4096,
+            "no_attribute_table": True,
+            "openocd": {
+                "prefix": 'source [find interface/stlink.cfg]; \
+                           interface hla; \
+                           source [find target/nrf52.cfg];',
+            },
+        },
     }
 
     def __init__(self, args):

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -599,6 +599,12 @@ def main():
         help="Specify the board that is being read from. Only used with --rtt.",
     )
     listen.add_argument(
+        "--jlink", action="store_true", help="Use JLinkExe. Only used with --rtt."
+    )
+    listen.add_argument(
+        "--openocd", action="store_true", help="Use OpenOCD. Only used with --rtt."
+    )
+    listen.add_argument(
         "--jlink-cmd", help="The JLinkExe binary to invoke. Only used with --rtt."
     )
     listen.add_argument(
@@ -619,6 +625,29 @@ def main():
         "--jlink-if",
         default="swd",
         help="The interface type to pass to JLinkExe. Only used with --rtt.",
+    )
+    listen.add_argument(
+        "--openocd-board",
+        help="The cfg file in OpenOCD `board` folder. Only used with --rtt.",
+    )
+    listen.add_argument(
+        "--openocd-cmd",
+        default="openocd",
+        help="The openocd binary to invoke. Only used with --rtt.",
+    )
+    listen.add_argument(
+        "--openocd-options",
+        default=[],
+        help="Tockloader-specific flags to direct how Tockloader uses OpenOCD. Only used with --rtt.",
+        nargs="*",
+    )
+    listen.add_argument(
+        "--openocd-commands",
+        default={},
+        type=lambda kv: kv.split("=", 1),
+        action=helpers.ListToDictAction,
+        help='Directly specify which OpenOCD commands to use for "program", "read", or "erase" actions. Example: "program=flash write_image erase {{binary}} {address:#x};verify_image {{binary}} {address:#x};" Only used with --rtt.',
+        nargs="*",
     )
     listen.set_defaults(func=command_listen)
 

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -658,7 +658,11 @@ class TockLoader:
         # here. There is no need to save the channel, since
         # `channel.run_terminal()` never returns.
         if self.args.rtt:
-            channel = JLinkExe(self.args)
+            if self.args.openocd:
+                channel = OpenOCD(self.args)
+            else:
+                channel = JLinkExe(self.args)
+
         else:
             channel = BootloaderSerial(self.args)
             channel.open_link_to_board(listen=True)


### PR DESCRIPTION
Hi,

as part of board bringup, I added the ability to listen to the RTT debug console using SMA Q3. This should work with the nrf52840dk kernel, but sma_q3 is the only device I can test it with, so I didn't bother removing.

I was a bit confused whether the "listen" command should inherit general argument configuration for OpenOCD, but decided to copy them for the sake of the "only works with --rtt" message.

One bigger change is the split up of the openocd command builder. To run RTT in OpenOCD, there is a need to pass an argument with a quote inside, and the existing command runner was tripped up by this, so I rewrote parts of it.

I'm putting this hoping for feedback, so that it can get merged.