### PR TITLE
Be user friendly when mixing fixed-address and PIC

### DIFF
--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -931,6 +931,10 @@ class TockLoader:
                 is_fixed_address_app = True
 
         if is_fixed_address_app:
+            if not all(map(lambda x: x.has_fixed_addresses(), apps)):
+                raise TockLoaderException(
+                    "Mixing fixed address and position-independent apps is currently unsupported"
+                )
             #
             # This is the fixed addresses case
             #


### PR DESCRIPTION
This gives a human-readable message instead of crashing. I ran into it when trying to debug libtock-rs.

I'd have fixed the root issue, but I'm struggling to run a static application on ARM at all right now, so I'll leave it for when I actually need it.

Before/after:

```
[tockloader]$ python3 ./start.py install --board=sma_q3 --openocd ../libtock-c/examples/blink/build/blink.tab
[...]
  File "/.../tockloader/tockloader/app_tab.py", line 189, in get_fixed_addresses_flash_and_sizes
    (tbf.tbfh.get_fixed_addresses()[1], tbf.tbfh.get_app_size())
TypeError: 'NoneType' object is not subscriptable
[tockloader]$ python3 ./start.py install --board=sma_q3 --openocd ../libtock-c/examples/blink/build/blink.tab 
[INFO   ] Using settings from KNOWN_BOARDS["sma_q3"]
[STATUS ] Installing app on the board...
[ERROR  ] Mixing fixed address and position-independent apps is currently unsupported
```