### PR TITLE
deps: Use toml instead pytoml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "colorama >= 0.3.7",
         "crcmod >= 1.7",
         "pyserial >= 3.0.1",
-        "pytoml >= 0.1.11",
+        "toml >= 0.10.2",
         "tqdm >= 4.45.0 ",
     ],
 )

--- a/tockloader/tab.py
+++ b/tockloader/tab.py
@@ -9,7 +9,7 @@ import tempfile
 import textwrap
 import urllib.request
 
-import pytoml
+import toml
 
 from .app_tab import TabApp
 from .app_tab import TabTbf
@@ -262,7 +262,7 @@ class TAB:
         # Otherwise parse f.toml file.
         metadata_tarinfo = self.tab.getmember("metadata.toml")
         metadata_str = self.tab.extractfile(metadata_tarinfo).read().decode("utf-8")
-        self.metadata = pytoml.loads(metadata_str)
+        self.metadata = toml.loads(metadata_str)
         return self.metadata
 
     def _get_metadata_key(self, key):


### PR DESCRIPTION
pytoml has been abandoned.

"The pytoml project is no longer being actively maintained."

It's also not available in up-to-date distributions like Fedora 35, making it hard to use tockloader there.