### PR TITLE
Add support for App IDs through Program Headers and TBF Footers

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,18 @@ Print which boards tockloader has default settings for built-in.
 
 Set the jump address the bootloader uses for the location of the kernel.
 
+#### `tockloader tbf-delete-tlv [TLVID]`
+
+Remove a TLV (by ID) from the TBF.
+
+#### `tockloader tbf-modify-tlv [TLVID] [field] [value]`
+
+Set a specific field (by name) to the given value in a specific TLV (by ID).
+
+#### `tockloader tbf-delete-credential [credential ID]`
+
+Remove a specific credential (by credential ID) from the TBF footer.
+
 
 Specifying the Board
 --------------------
@@ -226,6 +238,19 @@ operation based on the requirements of a particular hardware platform.
   bundle using only a single flash command. This will require that anytime any
   app changes in any way (e.g. its header changes or the app is updated or a new
   app is installed) all apps are re-written.
+
+Credentials and Integrity Support
+---------------------------------
+
+Tockloader supports working with credentials stored in the TBF footer.
+Tockloader will attempt to verify that stored credentials are valid for the
+given TBF. For credentials that require keys to verify, Tockloader can check the
+credential using:
+
+    $ tockloader inspect-tab --verify-credentials [list of key files]
+    example:
+    $ tockloader inspect-tab --verify-credentials tockkey.public.der
+
 
 Features
 --------

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "argcomplete >= 1.8.2",
         "colorama >= 0.3.7",
         "crcmod >= 1.7",
+        "pycryptodome >= 3.15.0",
         "pyserial >= 3.0.1",
         "toml >= 0.10.2",
         "tqdm >= 4.45.0 ",

--- a/tockloader/app_installed.py
+++ b/tockloader/app_installed.py
@@ -311,6 +311,7 @@ class InstalledApp:
             "size": self.get_size(),
             "address": self.address,
             "header": self.tbfh.object(),
+            "footer": self.tbff.object(),
         }
 
     def __str__(self):

--- a/tockloader/app_installed.py
+++ b/tockloader/app_installed.py
@@ -199,6 +199,14 @@ class InstalledApp:
         """
         return self.address
 
+    def verify_credentials(self, public_keys):
+        """
+        Using an optional array of public_key binaries, try to check any
+        contained credentials to verify they are valid.
+        """
+        integrity_blob = self.tbfh.get_binary() + self.app_binary
+        self.tbff.verify_credentials(public_keys, integrity_blob)
+
     def has_app_binary(self):
         """
         Whether we have the actual application binary for this app.

--- a/tockloader/app_installed.py
+++ b/tockloader/app_installed.py
@@ -31,6 +31,12 @@ class InstalledApp:
         """
         return self.tbfh.get_app_name()
 
+    def get_app_version(self):
+        """
+        Return the version number stored in a program header.
+        """
+        return self.tbfh.get_app_version()
+    
     def is_app(self):
         """
         Whether this is an app or padding.
@@ -273,6 +279,7 @@ class InstalledApp:
 
         out = ""
         out += "Name:                  {}\n".format(self.get_name())
+        out += "Version:               {}\n".format(self.get_app_version())
         out += "Enabled:               {}\n".format(self.tbfh.is_enabled())
         out += "Sticky:                {}\n".format(self.tbfh.is_sticky())
         out += "Total Size in Flash:   {} bytes\n".format(self.get_size())

--- a/tockloader/app_installed.py
+++ b/tockloader/app_installed.py
@@ -12,8 +12,9 @@ class InstalledApp:
     necessary if the app needs to be moved.
     """
 
-    def __init__(self, tbfh, address, app_binary=None):
-        self.tbfh = tbfh  # A `tbfh` object representing this app's header.
+    def __init__(self, tbfh, tbff, address, app_binary=None):
+        self.tbfh = tbfh  # A `TBFHeader` object representing this app's header.
+        self.tbff = tbff  # A `TBFFooter` object representing this app's footer.
         self.app_binary = app_binary  # A binary array of the app _after_ the header.
         self.address = address  # Where on the board this app currently is.
 
@@ -287,6 +288,8 @@ class InstalledApp:
         if verbose:
             out += "Address in Flash:      {:#x}\n".format(offset)
             out += textwrap.indent(str(self.tbfh), "  ")
+            if self.tbff:
+                out += textwrap.indent(str(self.tbff), "  ")
         return out
 
     def object(self):

--- a/tockloader/app_installed.py
+++ b/tockloader/app_installed.py
@@ -36,7 +36,7 @@ class InstalledApp:
         Return the version number stored in a program header.
         """
         return self.tbfh.get_app_version()
-    
+
     def is_app(self):
         """
         Whether this is an app or padding.

--- a/tockloader/app_tab.py
+++ b/tockloader/app_tab.py
@@ -340,6 +340,13 @@ class TabApp:
             integrity_blob = tbf.tbfh.get_binary() + tbf.binary
             tbf.tbff.verify_credentials(public_keys, integrity_blob)
 
+    def corrupt_tbf(self, field_name, value):
+        """
+        Modify the TBF root header just before installing the application.
+        """
+        for tbf in self.tbfs:
+            tbf.tbfh.corrupt_tbf(field_name, value)
+
     def has_app_binary(self):
         """
         Return true if we have an application binary with this app.

--- a/tockloader/app_tab.py
+++ b/tockloader/app_tab.py
@@ -314,6 +314,13 @@ class TabApp:
         for tbf in self.tbfs:
             tbf.tbfh.modify_tlv(tlvid, field, value)
 
+    def delete_credential(self, credential_id):
+        """
+        Remove a credential by ID from the TBF footer.
+        """
+        for tbf in self.tbfs:
+            tbf.tbff.delete_credential(credential_id)
+
     def verify_credentials(self, public_keys):
         """
         Using an optional array of public_key binaries, try to check any

--- a/tockloader/app_tab.py
+++ b/tockloader/app_tab.py
@@ -93,7 +93,7 @@ class TabApp:
         Return the footers if there are any.
         """
         if len(self.tbfs) == 1:
-            return self.tbfs[0].footers
+            return self.tbfs[0].tbff
         return None
 
     def get_size(self):

--- a/tockloader/app_tab.py
+++ b/tockloader/app_tab.py
@@ -299,12 +299,13 @@ class TabApp:
         else:
             return None
 
-    def delete_tbfh_tlv(self, tlvid):
+    def delete_tlv(self, tlvid):
         """
-        Delete a particular TLV from each TBF header.
+        Delete a particular TLV from each TBF header and footer.
         """
         for tbf in self.tbfs:
             tbf.tbfh.delete_tlv(tlvid)
+            tbf.tbff.delete_tlv(tlvid)
 
     def modify_tbfh_tlv(self, tlvid, field, value):
         """

--- a/tockloader/app_tab.py
+++ b/tockloader/app_tab.py
@@ -98,6 +98,17 @@ class TabApp:
         else:
             raise TockLoaderException("Size only valid with one TBF")
 
+    def get_app_version(self):
+        """
+        Return the version number stored in a program header.
+
+        This is only valid if there is only one TBF.
+        """
+        if len(self.tbfs) == 1:
+            return self.tbfs[0].tbfh.get_version()
+        else:
+            raise TockLoaderException("Size only valid with one TBF")
+
     def set_size(self, size):
         """
         Force the entire app to be a certain size. If `size` is smaller than the
@@ -389,6 +400,7 @@ class TabApp:
         """
         out = ""
         out += "Name:                  {}\n".format(self.get_name())
+        out += "Version:               {}\n".format(self.get_version())
         out += "Total Size in Flash:   {} bytes\n".format(self.get_size())
 
         if verbose:

--- a/tockloader/app_tab.py
+++ b/tockloader/app_tab.py
@@ -13,7 +13,7 @@ class TabTbf:
     This correlates to a specific .tbf file storing a .tab file.
     """
 
-    def __init__(self, filename, tbfh, binary, footers):
+    def __init__(self, filename, tbfh, binary, tbff):
         """
         - `filename` is the identifier used in the .tab.
         - `tbfh` is the header object
@@ -22,7 +22,7 @@ class TabTbf:
         self.filename = filename
         self.tbfh = tbfh
         self.binary = binary
-        self.footers = footers
+        self.tbff = tbff
 
 
 class TabApp:
@@ -333,15 +333,16 @@ class TabApp:
         if len(self.tbfs) == 1:
             tbfh = self.tbfs[0].tbfh
             app_binary = self.tbfs[0].binary
+            tbff = self.tbfs[0].tbff
 
             # If the TBF is not compiled for a fixed address, then we can just
             # use it.
             if tbfh.has_fixed_addresses() == False:
-                binary = tbfh.get_binary() + app_binary
+                binary = tbfh.get_binary() + app_binary + tbff.get_binary()
 
             else:
                 tbfh.adjust_starting_address(address)
-                binary = tbfh.get_binary() + app_binary
+                binary = tbfh.get_binary() + app_binary + tbff.get_binary()
 
             # Check that the binary is not longer than it is supposed to be.
             # This might happen if the size was changed, but any code using this

--- a/tockloader/app_tab.py
+++ b/tockloader/app_tab.py
@@ -314,6 +314,15 @@ class TabApp:
         for tbf in self.tbfs:
             tbf.tbfh.modify_tlv(tlvid, field, value)
 
+    def verify_credentials(self, public_keys):
+        """
+        Using an optional array of public_key binaries, try to check any
+        contained credentials to verify they are valid.
+        """
+        for tbf in self.tbfs:
+            integrity_blob = tbf.tbfh.get_binary() + tbf.binary
+            tbf.tbff.verify_credentials(public_keys, integrity_blob)
+
     def has_app_binary(self):
         """
         Return true if we have an application binary with this app.

--- a/tockloader/app_tab.py
+++ b/tockloader/app_tab.py
@@ -116,7 +116,7 @@ class TabApp:
         if len(self.tbfs) == 1:
             return self.tbfs[0].tbfh.get_version()
         else:
-            raise TockLoaderException("Size only valid with one TBF")
+            raise TockLoaderException("Version number only valid with one TBF")
 
     def set_size(self, size):
         """

--- a/tockloader/app_tab.py
+++ b/tockloader/app_tab.py
@@ -13,7 +13,7 @@ class TabTbf:
     This correlates to a specific .tbf file storing a .tab file.
     """
 
-    def __init__(self, filename, tbfh, binary):
+    def __init__(self, filename, tbfh, binary, footers):
         """
         - `filename` is the identifier used in the .tab.
         - `tbfh` is the header object
@@ -22,7 +22,7 @@ class TabTbf:
         self.filename = filename
         self.tbfh = tbfh
         self.binary = binary
-
+        self.footers = footers
 
 class TabApp:
     """
@@ -87,6 +87,14 @@ class TabApp:
             return self.tbfs[0].tbfh
         return None
 
+    def get_footers(self):
+        """
+        Return the footers if there are any.
+        """
+        if len(self.tbfs) == 1:
+            return self.tbfs[0].footers
+        return None
+    
     def get_size(self):
         """
         Return the total size (including TBF header) of this app in bytes.

--- a/tockloader/app_tab.py
+++ b/tockloader/app_tab.py
@@ -364,7 +364,7 @@ class TabApp:
         """
         out = []
         for tbf in self.tbfs:
-            binary = tbf.tbfh.get_binary() + tbf.binary
+            binary = tbf.tbfh.get_binary() + tbf.binary + tbf.tbff.get_binary()
             # Truncate in case the header grew and elf2tab padded the binary.
             binary = self._truncate_binary(binary)
             out.append((tbf.filename, binary))

--- a/tockloader/app_tab.py
+++ b/tockloader/app_tab.py
@@ -314,6 +314,14 @@ class TabApp:
         for tbf in self.tbfs:
             tbf.tbfh.modify_tlv(tlvid, field, value)
 
+    def add_credential(self, credential_type):
+        """
+        Add a credential by type to the TBF footer.
+        """
+        for tbf in self.tbfs:
+            integrity_blob = tbf.tbfh.get_binary() + tbf.binary
+            tbf.tbff.add_credential(credential_type, integrity_blob)
+
     def delete_credential(self, credential_id):
         """
         Remove a credential by ID from the TBF footer.

--- a/tockloader/app_tab.py
+++ b/tockloader/app_tab.py
@@ -314,13 +314,15 @@ class TabApp:
         for tbf in self.tbfs:
             tbf.tbfh.modify_tlv(tlvid, field, value)
 
-    def add_credential(self, credential_type):
+    def add_credential(self, credential_type, public_key, private_key):
         """
         Add a credential by type to the TBF footer.
         """
         for tbf in self.tbfs:
             integrity_blob = tbf.tbfh.get_binary() + tbf.binary
-            tbf.tbff.add_credential(credential_type, integrity_blob)
+            tbf.tbff.add_credential(
+                credential_type, public_key, private_key, integrity_blob
+            )
 
     def delete_credential(self, credential_id):
         """

--- a/tockloader/app_tab.py
+++ b/tockloader/app_tab.py
@@ -24,6 +24,7 @@ class TabTbf:
         self.binary = binary
         self.footers = footers
 
+
 class TabApp:
     """
     Representation of a Tock app for a specific architecture and board from a
@@ -94,7 +95,7 @@ class TabApp:
         if len(self.tbfs) == 1:
             return self.tbfs[0].footers
         return None
-    
+
     def get_size(self):
         """
         Return the total size (including TBF header) of this app in bytes.

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -412,6 +412,32 @@ def command_tbf_modify_tlv(args):
                 tab.update_tbf(app)
 
 
+def command_tbf_add_credential(args):
+    tabs = collect_tabs(args)
+
+    if len(tabs) == 0:
+        raise TockLoaderException("No TABs found, no TBF footers to process")
+
+    credential_type = args.credential_type
+    logging.status(
+        "Adding Credential type '{}' to the TBF footer...".format(credential_type)
+    )
+    for tab in tabs:
+        # Ask the user which TBF binaries to update.
+        tbf_names = tab.get_tbf_names()
+        index = helpers.menu(
+            tbf_names + ["All"],
+            return_type="index",
+            title="Which TBF to modify TLV?",
+            default_index=len(tbf_names),
+        )
+        for i, tbf_name in enumerate(tbf_names):
+            if i == index or index == len(tbf_names):
+                app = tab.extract_tbf(tbf_name)
+                app.add_credential(credential_type)
+                tab.update_tbf(app)
+
+
 def command_tbf_delete_credential(args):
     tabs = collect_tabs(args)
 
@@ -938,6 +964,19 @@ def main():
         "value", help="TLV field new value", type=lambda x: int(x, 0)
     )
     tbfmodifytlv.add_argument("tab", help="The TAB or TABs to modify", nargs="*")
+
+    tbfaddcredential = subparser.add_parser(
+        "tbf-add-credential",
+        parents=[parent],
+        help="Add a credential TLV from the TBF footer",
+    )
+    tbfaddcredential.set_defaults(func=command_tbf_add_credential)
+    tbfaddcredential.add_argument(
+        "credential_type",
+        help="Credential type to add",
+        choices=["sha256", "sha384", "sha512"],
+    )
+    tbfaddcredential.add_argument("tab", help="The TAB or TABs to modify", nargs="*")
 
     tbfdeletecredential = subparser.add_parser(
         "tbf-delete-credential",

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -422,6 +422,17 @@ def command_tbf_add_credential(args):
     logging.status(
         "Adding Credential type '{}' to the TBF footer...".format(credential_type)
     )
+
+    # Get keys
+    pub_key = None
+    pri_key = None
+    if args.public_key != None:
+        with open(args.public_key[0], "rb") as f:
+            pub_key = f.read()
+    if args.private_key != None:
+        with open(args.private_key[0], "rb") as f:
+            pri_key = f.read()
+
     for tab in tabs:
         # Ask the user which TBF binaries to update.
         tbf_names = tab.get_tbf_names()
@@ -434,7 +445,7 @@ def command_tbf_add_credential(args):
         for i, tbf_name in enumerate(tbf_names):
             if i == index or index == len(tbf_names):
                 app = tab.extract_tbf(tbf_name)
-                app.add_credential(credential_type)
+                app.add_credential(credential_type, pub_key, pri_key)
                 tab.update_tbf(app)
 
 
@@ -974,7 +985,17 @@ def main():
     tbfaddcredential.add_argument(
         "credential_type",
         help="Credential type to add",
-        choices=["sha256", "sha384", "sha512"],
+        choices=["sha256", "sha384", "sha512", "rsa4096"],
+    )
+    tbfaddcredential.add_argument(
+        "--public-key",
+        help="Public key to use in signature credential",
+        nargs=1,
+    )
+    tbfaddcredential.add_argument(
+        "--private-key",
+        help="Private key to use in signing credential",
+        nargs=1,
     )
     tbfaddcredential.add_argument("tab", help="The TAB or TABs to modify", nargs="*")
 

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -119,7 +119,7 @@ def command_list(args):
     tock_loader = TockLoader(args)
     tock_loader.open()
     tock_loader.list_apps(args.verbose, args.quiet)
-    
+
 
 def command_install(args):
     check_and_run_make(args)
@@ -343,7 +343,8 @@ def command_inspect_tab(args):
             if args.crt0_header:
                 print("  crt0 header")
                 print(textwrap.indent(app.get_crt0_header_str(), "    "))
-                
+
+            print("TBF Footers")
             print(textwrap.indent(str(app.get_footers()), "  "))
         print("")
 

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -412,6 +412,30 @@ def command_tbf_modify_tlv(args):
                 tab.update_tbf(app)
 
 
+def command_tbf_delete_credential(args):
+    tabs = collect_tabs(args)
+
+    if len(tabs) == 0:
+        raise TockLoaderException("No TABs found, no TBF footers to process")
+
+    credential_id = args.credential_id
+    logging.status("Removing Credential ID {} from TBF footer...".format(credential_id))
+    for tab in tabs:
+        # Ask the user which TBF binaries to update.
+        tbf_names = tab.get_tbf_names()
+        index = helpers.menu(
+            tbf_names + ["All"],
+            return_type="index",
+            title="Which TBF to modify TLV?",
+            default_index=len(tbf_names),
+        )
+        for i, tbf_name in enumerate(tbf_names):
+            if i == index or index == len(tbf_names):
+                app = tab.extract_tbf(tbf_name)
+                app.delete_credential(credential_id)
+                tab.update_tbf(app)
+
+
 def command_dump_flash_page(args):
     tock_loader = TockLoader(args)
     tock_loader.open()
@@ -914,6 +938,17 @@ def main():
         "value", help="TLV field new value", type=lambda x: int(x, 0)
     )
     tbfmodifytlv.add_argument("tab", help="The TAB or TABs to modify", nargs="*")
+
+    tbfdeletecredential = subparser.add_parser(
+        "tbf-delete-credential",
+        parents=[parent],
+        help="Delete a credential TLV from the TBF footer",
+    )
+    tbfdeletecredential.set_defaults(func=command_tbf_delete_credential)
+    tbfdeletecredential.add_argument(
+        "credential_id", help="Credential type number", type=lambda x: int(x, 0)
+    )
+    tbfdeletecredential.add_argument("tab", help="The TAB or TABs to modify", nargs="*")
 
     list_known_boards = subparser.add_parser(
         "list-known-boards",

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -344,7 +344,6 @@ def command_inspect_tab(args):
                 print("  crt0 header")
                 print(textwrap.indent(app.get_crt0_header_str(), "    "))
                 
-            print("TBF Footers")
             print(textwrap.indent(str(app.get_footers()), "  "))
         print("")
 

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -770,6 +770,11 @@ def main():
     install.add_argument(
         "--sticky", help="Make the installed app(s) sticky.", action="store_true"
     )
+    install.add_argument(
+        "--corrupt-tbf",
+        help="Modify the root TBF header when installing an app.",
+        nargs=2,
+    )
 
     update = subparser.add_parser(
         "update",

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -119,7 +119,7 @@ def command_list(args):
     tock_loader = TockLoader(args)
     tock_loader.open()
     tock_loader.list_apps(args.verbose, args.quiet)
-
+    
 
 def command_install(args):
     check_and_run_make(args)
@@ -343,7 +343,9 @@ def command_inspect_tab(args):
             if args.crt0_header:
                 print("  crt0 header")
                 print(textwrap.indent(app.get_crt0_header_str(), "    "))
-
+                
+            print("TBF Footers")
+            print(textwrap.indent(str(app.get_footers()), "  "))
         print("")
 
 

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -353,10 +353,10 @@ def command_tbf_delete_tlv(args):
     tabs = collect_tabs(args)
 
     if len(tabs) == 0:
-        raise TockLoaderException("No TABs found, no TBF headers to process")
+        raise TockLoaderException("No TABs found, no TBF to process")
 
     tlvid = args.tlvid
-    logging.status("Removing TLV ID {} from TBF headers...".format(tlvid))
+    logging.status("Removing TLV ID {} from TBF...".format(tlvid))
     for tab in tabs:
         # Ask the user which TBF binaries to update.
         tbf_names = tab.get_tbf_names()
@@ -369,7 +369,7 @@ def command_tbf_delete_tlv(args):
         for i, tbf_name in enumerate(tbf_names):
             if i == index or index == len(tbf_names):
                 app = tab.extract_tbf(tbf_name)
-                app.delete_tbfh_tlv(tlvid)
+                app.delete_tlv(tlvid)
                 tab.update_tbf(app)
 
 

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -116,9 +116,19 @@ def command_listen(args):
 
 
 def command_list(args):
+    # Optimistically try to verify any included credentials if asked to. We have
+    # to read in the actual key contents.
+    public_keys = None
+    if args.verify_credentials != None:
+        public_keys = []
+        if args.verify_credentials:
+            for key_path in args.verify_credentials:
+                with open(key_path, "rb") as f:
+                    public_keys.append(f.read())
+
     tock_loader = TockLoader(args)
     tock_loader.open()
-    tock_loader.list_apps(args.verbose, args.quiet)
+    tock_loader.list_apps(args.verbose, args.quiet, public_keys)
 
 
 def command_install(args):
@@ -791,6 +801,11 @@ def main():
         "-q",
         help="Print just a list of application names",
         action="store_true",
+    )
+    listcmd.add_argument(
+        "--verify-credentials",
+        help="Check credentials with a list of public keys",
+        nargs="*",
     )
 
     info = subparser.add_parser(

--- a/tockloader/tab.py
+++ b/tockloader/tab.py
@@ -90,14 +90,14 @@ class TAB:
                     # longer than the amount of reserved space (`total_size` in the
                     # TBF header) for the app.
                     raise TockLoaderException(
-                        "Invalid TAB, the app binary is longer than its defined total_size"
+                        "Invalid TAB, the app binary is longer ", len(binary), " than its defined total_size", tbfh.get_app_size()
                     )
 
                 tbfs.append(
                     TabTbf(tbf_filename, tbfh, binary[tbfh.get_size_before_app() :])
                 )
             else:
-                raise TockLoaderException("Invalid TBF found in app in TAB")
+                raise TockLoaderException("Invalid TBF found in app in TAB:", str(tbfh))
 
         return TabApp(tbfs)
 

--- a/tockloader/tab.py
+++ b/tockloader/tab.py
@@ -249,7 +249,7 @@ than its defined total_size ({} bytes)".format(
 
             # Extract the footer if any should exist. It is OK if the footer
             # buffer is zero length, the footer object will just be empty.
-            tbff = TBFFooter(binary[start_of_footers:])
+            tbff = TBFFooter(tbfh, binary[start_of_footers:])
 
             # Finally we can return the TBF.
             return TabTbf(

--- a/tockloader/tab.py
+++ b/tockloader/tab.py
@@ -90,11 +90,21 @@ class TAB:
                     # longer than the amount of reserved space (`total_size` in the
                     # TBF header) for the app.
                     raise TockLoaderException(
-                        "Invalid TAB, the app binary is longer ", len(binary), " than its defined total_size", tbfh.get_app_size()
+                        "Invalid TAB, the app binary is longer ",
+                        len(binary),
+                        " than its defined total_size",
+                        tbfh.get_app_size(),
                     )
-                tbff = TBFFooters(binary[tbfh.get_binary_end_offset():])
+                tbff = TBFFooters(binary[tbfh.get_binary_end_offset() :])
                 tbfs.append(
-                    TabTbf(tbf_filename, tbfh, binary[tbfh.get_size_before_app(): tbfh.get_binary_end_offset()], tbff)
+                    TabTbf(
+                        tbf_filename,
+                        tbfh,
+                        binary[
+                            tbfh.get_size_before_app() : tbfh.get_binary_end_offset()
+                        ],
+                        tbff,
+                    )
                 )
             else:
                 raise TockLoaderException("Invalid TBF found in app in TAB:", str(tbfh))
@@ -122,13 +132,17 @@ class TAB:
                 raise TockLoaderException(
                     "Invalid TAB, the app binary is longer than its defined total_size"
                 )
-            print("Making a TAB app with len", str(len(binary)),
-                  "binary end offset", str(tbfh.get_binary_end_offset()))
-            app_binary = binary[tbfh.get_size_before_app():tbfh.get_binary_end_offset()]
-            app_footers = TBFFooters(binary[tbfh.get_binary_end_offset():])
-            return TabApp(
-                [TabTbf(tbf_filename, tbfh, app_binary, app_footers)]
+            print(
+                "Making a TAB app with len",
+                str(len(binary)),
+                "binary end offset",
+                str(tbfh.get_binary_end_offset()),
             )
+            app_binary = binary[
+                tbfh.get_size_before_app() : tbfh.get_binary_end_offset()
+            ]
+            app_footers = TBFFooters(binary[tbfh.get_binary_end_offset() :])
+            return TabApp([TabTbf(tbf_filename, tbfh, app_binary, app_footers)])
         else:
             raise TockLoaderException("Invalid TBF found in app in TAB")
 

--- a/tockloader/tab.py
+++ b/tockloader/tab.py
@@ -247,15 +247,18 @@ than its defined total_size ({} bytes)".format(
             start_of_app_binary = tbfh.get_size_before_app()
             start_of_footers = tbfh.get_binary_end_offset()
 
+            # Get application binary code.
+            app_binary = binary[start_of_app_binary:start_of_footers]
+
             # Extract the footer if any should exist. It is OK if the footer
             # buffer is zero length, the footer object will just be empty.
-            tbff = TBFFooter(tbfh, binary[start_of_footers:])
+            tbff = TBFFooter(tbfh, app_binary, binary[start_of_footers:])
 
             # Finally we can return the TBF.
             return TabTbf(
                 tbf_filename,
                 tbfh,
-                binary[start_of_app_binary:start_of_footers],
+                app_binary,
                 tbff,
             )
         else:

--- a/tockloader/tbfh.py
+++ b/tockloader/tbfh.py
@@ -132,7 +132,7 @@ class TBFTLVProgram(TBFTLV):
             "binary_end_offset", self.binary_end_offset, self.binary_end_offset
         )
         out += "  {:<20}: {:>10} {:>#12x}\n".format(
-            "version", self.app_version, self.app_version
+            "app_version", self.app_version, self.app_version
         )
         return out
 

--- a/tockloader/tbfh.py
+++ b/tockloader/tbfh.py
@@ -38,7 +38,7 @@ class TBFTLVUnknown(TBFTLV):
         # Need to ensure that whatever this header is that it is a multiple
         # of 4 in length.
         padding = (4 - (len(out) % 4)) % 4
-        out += b"0" * padding
+        out += b"\0" * padding
 
         return out
 

--- a/tockloader/tbfh.py
+++ b/tockloader/tbfh.py
@@ -972,7 +972,7 @@ class TBFFooter:
         self.data = data
 
     def __str__(self):
-        out = ""
+        out =  "TBF Footer\n"
         out += "  Type: {}\n".format(self.credentials_type)
         out += "  Length: {}\n".format(len(self.data))
         out += "  Data: "

--- a/tockloader/tbfh.py
+++ b/tockloader/tbfh.py
@@ -99,10 +99,22 @@ class TBFTLVMain(TBFTLV):
 class TBFTLVProgram(TBFTLV):
     TLVID = 0x09
 
-    def __init__(self, buffer):
+    def __init__(self, buffer, total_size=0):
+        """
+        Create a Program TLV. To create an empty program TLV, pass `None` in as
+        the buffer and the total size of the app in `total_size`.
+        """
         self.valid = False
 
-        if len(buffer) == 20:
+        if buffer == None:
+            self.init_fn_offset = 0
+            self.protected_size = 0
+            self.minimum_ram_size = 0
+            self.binary_end_offset = total_size
+            self.app_version = 0
+            self.valid = True
+
+        elif len(buffer) == 20:
             base = struct.unpack("<IIIII", buffer)
             self.init_fn_offset = base[0]
             self.protected_size = base[1]
@@ -906,6 +918,10 @@ class TBFHeader:
         tlv = self._get_tlv(self.HEADER_TYPE_PROGRAM)
         if tlv == None:
             tlv = self._get_tlv(self.HEADER_TYPE_MAIN)
+            if tlv == None:
+                # If we don't have either a program or main header then we use
+                # an empty program header.
+                tlv = TBFTLVProgram(None, self.get_app_size())
         return tlv
 
     def _get_tlv(self, tlvid):

--- a/tockloader/tbfh.py
+++ b/tockloader/tbfh.py
@@ -1257,6 +1257,22 @@ class TBFFooter:
             self.tlvs.pop(index)
             self.modified = True
 
+    def delete_credential(self, credential_id):
+        """
+        Remove credential by credential type.
+        """
+        indices = []
+        for i, tlv in enumerate(self.tlvs):
+            if tlv.get_tlvid() == self.FOOTER_TYPE_CREDENTIALS:
+                if tlv.credentials_type == credential_id:
+                    # Reverse the list
+                    indices.insert(0, i)
+        # Pop starting with the last match
+        for index in indices:
+            logging.debug("Removing credential TLV at index {}".format(index))
+            self.tlvs.pop(index)
+            self.modified = True
+
     def verify_credentials(self, public_keys, integrity_blob):
         """
         Check credential TLVs with an optional array of public keys (stored as

--- a/tockloader/tbfh.py
+++ b/tockloader/tbfh.py
@@ -1014,7 +1014,7 @@ class TBFFooterTLVCredentials(TBFTLV):
 
     TLVID = 0x80
 
-    CREDENTIALS_TYPE_PADDING = 0x00
+    CREDENTIALS_TYPE_RESERVED = 0x00
     CREDENTIALS_TYPE_CLEARTEXTID = 0x01
     CREDENTIALS_TYPE_RSA3072KEY = 0x02
     CREDENTIALS_TYPE_RSA4096KEY = 0x03
@@ -1034,10 +1034,10 @@ class TBFFooterTLVCredentials(TBFTLV):
             credentials_type = struct.unpack("<I", buffer[0:4])[0]
 
             # Check each credentials type.
-            if credentials_type == self.CREDENTIALS_TYPE_PADDING:
-                self.credentials_type = self.CREDENTIALS_TYPE_PADDING
+            if credentials_type == self.CREDENTIALS_TYPE_RESERVED:
+                self.credentials_type = self.CREDENTIALS_TYPE_RESERVED
                 self.buffer = buffer[4:]
-                # We accept any size padding.
+                # We accept any size of reserved area for future credentials.
                 self.valid = True
             elif credentials_type == self.CREDENTIALS_TYPE_SHA256:
                 self.credentials_type = self.CREDENTIALS_TYPE_SHA256
@@ -1067,7 +1067,7 @@ class TBFFooterTLVCredentials(TBFTLV):
 
     def _credentials_type_to_str(self):
         names = [
-            "Padding",
+            "Reserved",
             "ClearTextID",
             "RSA3072KEY",
             "RSA4096KEY",

--- a/tockloader/tbfh.py
+++ b/tockloader/tbfh.py
@@ -1461,7 +1461,15 @@ class TBFFooter:
         return buf
 
     def __str__(self):
-        out = ""
+        footer_size = 0
+        for tlv in self.tlvs:
+            footer_size += tlv.get_size()
+
+        out = "Footer\n"
+        out += "{:<22}: {:>10} {:>#12x}\n".format(
+            "  footer_size", footer_size, footer_size
+        )
+
         for tlv in self.tlvs:
             out += str(tlv)
         return out

--- a/tockloader/tbfh.py
+++ b/tockloader/tbfh.py
@@ -91,8 +91,6 @@ class TBFTLVProgram(TBFTLV):
             self.binary_end_offset = base[3]
             self.app_version = base[4]
             self.valid = True
-        else:
-            print("Bad buffer for Program TLV it is length", str(len(buffer)))
 
     def pack(self):
         return struct.pack(
@@ -440,8 +438,7 @@ class TBFHeader:
 
                         elif tipe == self.HEADER_TYPE_PROGRAM:
                             if remaining >= 20 and length == 20:
-                                program = TBFTLVProgram(buffer[0:20])
-                                self.tlvs.append(program)
+                                self.tlvs.append(TBFTLVProgram(buffer[0:20]))
 
                         elif tipe == self.HEADER_TYPE_WRITEABLE_FLASH_REGIONS:
                             if remaining >= length:

--- a/tockloader/tbfh.py
+++ b/tockloader/tbfh.py
@@ -155,6 +155,17 @@ class TBFTLVProgram(TBFTLV):
         )
         return out
 
+    def object(self):
+        return {
+            "type": "program",
+            "id": self.TLVID,
+            "init_fn_offset": self.init_fn_offset,
+            "protected_size": self.protected_size,
+            "minimum_ram_size": self.minimum_ram_size,
+            "binary_end_offset": self.binary_end_offset,
+            "app_version": self.app_version,
+        }
+
 
 class TBFTLVWriteableFlashRegions(TBFTLV):
     TLVID = 0x02
@@ -1269,6 +1280,15 @@ class TBFFooterTLVCredentials(TBFTLV):
         # out += "\n\n"
         return out
 
+    def object(self):
+        return {
+            "type": "credential",
+            "id": self.TLVID,
+            "credential_type": self._credentials_type_to_str(),
+            "length": len(self.buffer),
+            "verified": self.verified,
+        }
+
 
 class TBFFooterTLVCredentialsConstructor(TBFFooterTLVCredentials):
     def __init__(self, credential_id):
@@ -1504,10 +1524,14 @@ class TBFFooter:
 
         return buf
 
-    def __str__(self):
+    def get_size(self):
         footer_size = 0
         for tlv in self.tlvs:
             footer_size += tlv.get_size()
+        return footer_size
+
+    def __str__(self):
+        footer_size = self.get_size()
 
         out = "Footer\n"
         out += "{:<22}: {:>10} {:>#12x}\n".format(
@@ -1516,4 +1540,12 @@ class TBFFooter:
 
         for tlv in self.tlvs:
             out += str(tlv)
+        return out
+
+    def object(self):
+        out = {"version": self.version, "tlvs": []}
+
+        for tlv in self.tlvs:
+            out["tlvs"].append(tlv.object())
+
         return out

--- a/tockloader/tbfh.py
+++ b/tockloader/tbfh.py
@@ -1030,7 +1030,7 @@ class TBFFooterTLVCredentials(TBFTLV):
 
         # This TLV requires the first field to be the credentials type. Extract
         # that, then verify the remainder of the buffer is as we expect.
-        if len(buffer) > 4:
+        if len(buffer) >= 4:
             credentials_type = struct.unpack("<I", buffer[0:4])[0]
 
             # Check each credentials type.

--- a/tockloader/tbfh.py
+++ b/tockloader/tbfh.py
@@ -1007,7 +1007,7 @@ class TBFHeaderPadding(TBFHeader):
         self.fields["checksum"] = self._checksum(self.get_binary())
 
 
-class TBFFooterTLVCredentials:
+class TBFFooterTLVCredentials(TBFTLV):
     """
     Represent a Credentials TLV in the footer of a TBF.
     """
@@ -1120,6 +1120,8 @@ class TBFFooter:
         self.version = tbfh.version
         # List of all TLVs in the footer.
         self.tlvs = []
+        # Keep track if tockloader has modified the footer.
+        self.modified = False
 
         # Iterate all TLVs and add to list.
         position = 0
@@ -1135,6 +1137,21 @@ class TBFFooter:
                     self.tlvs.append(TBFFooterTLVCredentials(buffer[0:tlv_length]))
 
             buffer = buffer[tlv_length:]
+
+    def delete_tlv(self, tlvid):
+        """
+        Delete a particular TLV by ID if it exists.
+        """
+        indices = []
+        for i, tlv in enumerate(self.tlvs):
+            if tlv.get_tlvid() == tlvid:
+                # Reverse the list
+                indices.insert(0, i)
+        # Pop starting with the last match
+        for index in indices:
+            logging.debug("Removing TLV at index {}".format(index))
+            self.tlvs.pop(index)
+            self.modified = True
 
     def get_binary(self):
         """

--- a/tockloader/tbfh.py
+++ b/tockloader/tbfh.py
@@ -976,8 +976,22 @@ class TBFHeader:
             "sticky", ["No", "Yes"][(self.fields["flags"] >> 1) & 0x01]
         )
 
+        # Base header takes 16 bytes.
+        index = 16
+
         for tlv in self.tlvs:
-            out += str(tlv)
+            # Format the offset so we know the size of each TLV.
+            offset = "[{:<#5x}] ".format(index)
+            # Create the base TLV format.
+            tlv_str = str(tlv)
+            # Insert the address at the end of the first line of the TLV str.
+            lines = tlv_str.split("\n")
+            lines[0] = "{:<48}{}".format(lines[0], offset)
+            # Recreate string.
+            out += "\n".join(lines)
+
+            # Increment the byte index with the size of the TLV.
+            index += tlv.get_size()
 
         return out
 

--- a/tockloader/tbfh.py
+++ b/tockloader/tbfh.py
@@ -103,7 +103,7 @@ class TBFTLVProgram(TBFTLV):
             self.protected_size,
             self.minimum_ram_size,
             self.binary_end_offset,
-            self.app_version
+            self.app_version,
         )
 
     def __str__(self):
@@ -128,7 +128,7 @@ class TBFTLVProgram(TBFTLV):
 
 class TBFTLVWriteableFlashRegions(TBFTLV):
     TLVID = 0x02
-    
+
     def __init__(self, buffer):
         self.valid = False
 
@@ -361,12 +361,12 @@ class TBFHeader:
         # Initialize to None so a Main header will set it only if a Program
         # Header hasn't set it already.
         self.binary_end_offset = None
-        
+
         # The base fields in the TBF header.
         self.fields = {}
         # A list of TLV entries.
         self.tlvs = []
-        
+
         full_buffer = buffer
 
         # Need at least a version number
@@ -414,15 +414,15 @@ class TBFHeader:
             self.fields["checksum"] = base[3]
 
             if (
-                    len(full_buffer) >= self.fields["header_size"]
-                    and self.fields["header_size"] >= 16
+                len(full_buffer) >= self.fields["header_size"]
+                and self.fields["header_size"] >= 16
             ):
                 # Zero out checksum for checksum calculation.
                 nbuf = bytearray(self.fields["header_size"])
                 nbuf[:] = full_buffer[0 : self.fields["header_size"]]
                 struct.pack_into("<I", nbuf, 12, 0)
                 checksum = self._checksum(nbuf)
-                
+
                 remaining = self.fields["header_size"] - 16
 
                 # Now check to see if this is an app or padding.
@@ -618,7 +618,7 @@ class TBFHeader:
         if tlv:
             return tlv.package_name
         elif (
-                "package_name_offset" in self.fields and "package_name_size" in self.fields
+            "package_name_offset" in self.fields and "package_name_size" in self.fields
         ):
             return (
                 self.fields["package_name_offset"],
@@ -754,7 +754,9 @@ class TBFHeader:
                 ):
                     # The header is too small, so we can fix it.
                     delta = tlv_fixed_addr.fixed_address_flash - (
-                        address + self.fields["header_size"] + tlv_program.protected_size
+                        address
+                        + self.fields["header_size"]
+                        + tlv_program.protected_size
                     )
                     # Increase the protected size to match this.
                     tlv_program.protected_size += delta
@@ -860,7 +862,7 @@ class TBFHeader:
         if tlv == None:
             tlv = self._get_tlv(self.HEADER_TYPE_MAIN)
         return tlv
-    
+
     def _get_tlv(self, tlvid):
         """
         Return the TLV from the self.tlvs array if it exists.
@@ -965,8 +967,8 @@ class TBFHeaderPadding(TBFHeader):
         self.fields["flags"] = 0
         self.fields["checksum"] = self._checksum(self.get_binary())
 
-class TBFFooter:
 
+class TBFFooter:
     def __init__(self, credentials_type, data):
         self.credentials_type = credentials_type
         self.data = data
@@ -979,22 +981,22 @@ class TBFFooter:
         out += " ".join("{:02x}".format(x) for x in self.data)
         out += "\n\n"
         return out
-    
-    
+
+
 class TBFFooters:
     FOOTER_TYPE_CREDENTIALS = 0x80
-    CREDENTIALS_TYPE_PADDING      = 0x00
-    CREDENTIALS_TYPE_CLEARTEXTID  = 0x01
-    CREDENTIALS_TYPE_RSA3072KEY   = 0x02
-    CREDENTIALS_TYPE_RSA4096KEY   = 0x03
+    CREDENTIALS_TYPE_PADDING = 0x00
+    CREDENTIALS_TYPE_CLEARTEXTID = 0x01
+    CREDENTIALS_TYPE_RSA3072KEY = 0x02
+    CREDENTIALS_TYPE_RSA4096KEY = 0x03
     CREDENTIALS_TYPE_RSA3072KEYID = 0x04
     CREDENTIALS_TYPE_RSA4096KEYID = 0x05
-    CREDENTIALS_TYPE_SHA256       = 0x06
-    CREDENTIALS_TYPE_SHA384       = 0x07
-    CREDENTIALS_TYPE_SHA512       = 0x08
-            
+    CREDENTIALS_TYPE_SHA256 = 0x06
+    CREDENTIALS_TYPE_SHA384 = 0x07
+    CREDENTIALS_TYPE_SHA512 = 0x08
+
     def __init__(self, buffer):
-        
+
         self.footers = []
         position = 0
 
@@ -1013,16 +1015,15 @@ class TBFFooters:
                     if credentials_type == self.CREDENTIALS_TYPE_PADDING:
                         self.footers.append(TBFFooter("Padding", buffer[4:tlv_length]))
                     elif credentials_type == self.CREDENTIALS_TYPE_SHA256:
-                        self.footers.append(TBFFooter("SHA256", buffer[4:tlv_length]));
+                        self.footers.append(TBFFooter("SHA256", buffer[4:tlv_length]))
                     elif credentials_type == self.CREDENTIALS_TYPE_RSA4096KEY:
                         self.footers.append(TBFFooter("RSA4096", buffer[4:tlv_length]))
                     else:
                         print("Found unrecognized footer type:", credentials_type)
-            buffer = buffer[tlv_length-4:]
-                                       
+            buffer = buffer[tlv_length - 4 :]
+
     def __str__(self):
         out = ""
         for footer in self.footers:
             out += str(footer)
         return out
-            

--- a/tockloader/tbfh.py
+++ b/tockloader/tbfh.py
@@ -974,7 +974,7 @@ class TBFFooter:
         self.data = data
 
     def __str__(self):
-        out =  "TBF Footer\n"
+        out = "TBF Footer\n"
         out += "  Type: {}\n".format(self.credentials_type)
         out += "  Length: {}\n".format(len(self.data))
         out += "  Data: "

--- a/tockloader/tbfh.py
+++ b/tockloader/tbfh.py
@@ -1188,7 +1188,7 @@ class TBFFooterTLVCredentials(TBFTLV):
         if self.verified == "yes":
             verified = " ✓ verified"
         elif self.verified == "no":
-            verified = " ✗ NOT verified"
+            verified = " ✗ verified failed"
 
         out = "Footer TLV: Credentials ({})\n".format(self.TLVID)
         out += "  Type: {} ({}){}\n".format(

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -446,10 +446,12 @@ class TockLoader:
                     # And let the user know the state of the world now that we're done
                     apps = self._extract_all_app_headers()
                     if len(apps):
+                        app_names = ", ".join(map(lambda x: x.get_name(), apps))
                         logging.info(
-                            "After uninstall, remaining apps on board: ", end=""
+                            "After uninstall, remaining apps on board: {}".format(
+                                app_names
+                            )
                         )
-                        self._print_apps(apps, verbose=False, quiet=True)
                     else:
                         logging.info("After uninstall, no apps on board.")
 

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -230,7 +230,7 @@ class TockLoader:
                 binary = binary + extra
 
             self.channel.flash_binary(address, binary)
-
+            print("Wrote ", len(binary), " bytes of binary")
             # Flash command can optionally set attributes.
             if self.args.set_attribute != None:
                 for k, v in self.args.set_attribute:

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -231,7 +231,7 @@ class TockLoader:
                 binary = binary + extra
 
             self.channel.flash_binary(address, binary)
-            print("Wrote ", len(binary), " bytes of binary")
+
             # Flash command can optionally set attributes.
             if self.args.set_attribute != None:
                 for k, v in self.args.set_attribute:

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -1255,7 +1255,7 @@ class TockLoader:
                             )
                         )
                         flash = self.channel.read_range(footer_start, footer_length)
-                        tbff = TBFFooter(tbfh, flash)
+                        tbff = TBFFooter(tbfh, None, flash)
 
                     app = InstalledApp(tbfh, tbff, address)
                     apps.append(app)

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -1369,6 +1369,11 @@ class TockLoader:
             # Enforce other sizing constraints here.
             app.set_size_constraint(self.app_settings["size_constraint"])
 
+            if self.args.corrupt_tbf:
+                app.corrupt_tbf(
+                    self.args.corrupt_tbf[0], int(self.args.corrupt_tbf[1], 0)
+                )
+
             apps.append(app)
 
         if len(apps) == 0:


### PR DESCRIPTION
This PR is for adding support for App IDs in Tock userspace binaries. Support for App IDs involves changes to the TBF format, introducing a new Program Header type as well as TBF Footers. This PR has Tockloader support these and be able to parse them.

This also adds support to `inspect-tab` to print out and view footers.