### PR TITLE
TabApp.app_has_binary: reflect empty TBF list, check during install

### DIFF
--- a/tockloader/app_tab.py
+++ b/tockloader/app_tab.py
@@ -292,8 +292,10 @@ class TabApp:
         """
         Return true if we have an application binary with this app.
         """
-        # By definition, a TabApp will have an app binary.
-        return True
+        # By definition, a TabApp which is constructed over at least one TBF
+        # will have an app binary. However, it is possible to construct a TabApp
+        # over no TBFs, in which case it has no binary associated:
+        return len(self.tbfs) != 0
 
     def get_binary(self, address):
         """

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -1308,6 +1308,11 @@ class TockLoader:
             # This app is good to install, continue the process.
 
             app = tab.extract_app(arch)
+            if not app.has_app_binary():
+                raise TockLoaderException(
+                    "Unable to locate a valid application binary matching the "
+                    + f"target architecture ({arch})"
+                )
 
             # Enforce other sizing constraints here.
             app.set_size_constraint(self.app_settings["size_constraint"])


### PR DESCRIPTION
In case of a missing binary compiled for a certain architecture, missspelled architecture name, or an otherwise invalid TBF, it is possible for an AppTbf to be constructed over an empty TBF list. In this case, this should be reflected in the result of the `app_has_binary` method. Furthermore, Tockloader should verify that `extract_app` yields a `TabApp` for which `app_has_binary` is true.

Without this change, when trying to install an app for an architecture where no compiled binary exists, an error such as the following is encountered:

    [STATUS ] Installing app on the board...
    [ERROR  ] Size only valid with one TBF

This error message is misleading, as it occurs only when shuffling apps in the PIC code path, as no app requring fixed address placement is found, and also has no apparent relation to an architecture's app binaries not being found. Now, a more helpful message is shown:

    [STATUS ] Installing app on the board...
    [ERROR  ] Unable to locate a valid application binary matching the target architecture (rv32i)
