### PR TITLE
board_interface: update litex_sim architecture to rv32imc

### DIFF
--- a/tockloader/board_interface.py
+++ b/tockloader/board_interface.py
@@ -146,7 +146,7 @@ class BoardInterface:
         },
         "litex_sim": {
             "description": "LiteX SoC running on Verilated simulation",
-            "arch": "rv32i",
+            "arch": "rv32imc",
             "no_attribute_table": True,
             "flash_file": {
                 # This corresponds to the --integrated-rom-size when starting


### PR DESCRIPTION
This is in line with changes to the LiteX simulation command line invocation as documented in Tock, changes to the Tock board configuration and changes to libtock-c's app configuration.