### PR TITLE
display.py: add missing logging import

### DIFF
--- a/tockloader/display.py
+++ b/tockloader/display.py
@@ -4,6 +4,7 @@ Utilities for creating output in various formats.
 
 import json
 import textwrap
+import logging
 
 from . import helpers
 


### PR DESCRIPTION
This fixes an issue where calling `tockloader list` on a board with no apps would raise an exception which is propagated to the console:

    Traceback (most recent call last):
      File "tockloader-1.8.0-dev/bin/.tockloader-wrapped", line 9, in <module>
        sys.exit(main())
      File "/tockloader/tockloader/main.py", line 935, in main
        args.func(args)
      File "/tockloader/tockloader/main.py", line 121, in command_list
        tock_loader.list_apps(args.verbose, args.quiet)
      File "/tockloader/tockloader/tockloader.py", line 259, in list_apps
        displayer.list_apps(apps, verbose, quiet)
      File "/tockloader/tockloader/display.py", line 74, in list_apps
        logging.info("No found apps.")
    NameError: name 'logging' is not defined
