### PR TITLE
Add support for the QEMU RISC-V 32 bit "virt" Platform

### DIFF
--- a/tockloader/board_interface.py
+++ b/tockloader/board_interface.py
@@ -154,6 +154,18 @@ class BoardInterface:
                 "max_size": 0x00100000,
             },
         },
+        "qemu_rv32_virt": {
+            "description": "QEMU RISC-V 32 bit virt Platform",
+            "arch": "rv32imac",
+            # The QEMU-provided binary will be loaded at address 0x80000000
+            "address_translator": lambda addr: addr - 0x80000000,
+            "no_attribute_table": True,
+            "flash_file": {
+                # Size of the ROM and PROG region combined, where the resulting
+                # binary will be loaded into by QEMU:
+                "max_size": 0x00200000,
+            },
+        },
         "stm32f3discovery": {
             "description": "STM32F3-based Discovery Boards",
             "arch": "cortex-m4",

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -108,6 +108,7 @@ class TockLoader:
             "litex_sim": {"start_address": 0x00080000},
             "nucleof4": {"start_address": 0x08040000},
             "microbit_v2": {"start_address": 0x00040000},
+            "qemu_rv32_virt": {"start_address": 0x80100000},
             "stm32f3discovery": {"start_address": 0x08020000},
             "stm32f4discovery": {"start_address": 0x08040000},
             "raspberry_pi_pico": {"start_address": 0x10020000},


### PR DESCRIPTION
This adds support for the `qemu_rv32_virt` board as supported by Tock.
