### PR TITLE
board_interface: add particle boron

### DIFF
--- a/tockloader/board_interface.py
+++ b/tockloader/board_interface.py
@@ -273,6 +273,15 @@ class BoardInterface:
                            source [find target/nrf52.cfg];",
             },
         },
+        "particle_boron": {
+            "description": "nRF52-based cellular enabled development kit",
+            "arch": "cortex-m4",
+            "page_size": 4096,
+            "no_attribute_table": True,
+            "jlink": {
+                "device": "nrf52",
+            },
+        },
     }
 
     def __init__(self, args):


### PR DESCRIPTION
Add support to the `particle_boron` dev board. Tested on v1.9.0 with:

- `python3 -m tockloader.main install --board particle_boron --jlink <path_to_tab>`

- `python3 -m tockloader.main uninstall --board particle_boron --jlink`

Supports https://github.com/tock/tock/pull/3196

Let me know if I missed anything with this, new to Tockloader :)