### PR TITLE
Implement debug command

### DIFF
--- a/tockloader/board_interface.py
+++ b/tockloader/board_interface.py
@@ -594,3 +594,9 @@ class BoardInterface:
             binary = binary + after_binary
 
         return (address, binary)
+
+    def debug_binary(self, binary):
+        """
+        Debug the binary on the board.
+        """
+        return

--- a/tockloader/jlinkexe.py
+++ b/tockloader/jlinkexe.py
@@ -461,6 +461,4 @@ class JLinkExe(BoardInterface):
                 print(l, end="")
 
     def debug(self, binary):
-        logging.error(
-            "This functionality is not implemented for JLink"
-        )
+        raise TockLoaderException("This functionality is not implemented for JLink")

--- a/tockloader/jlinkexe.py
+++ b/tockloader/jlinkexe.py
@@ -459,3 +459,8 @@ class JLinkExe(BoardInterface):
             l = stdout_line.decode("utf-8")
             if not l.startswith("###RTT Client: *"):
                 print(l, end="")
+
+    def debug(self, binary):
+        logging.error(
+            "This functionality is not implemented for JLink"
+        )

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -250,6 +250,20 @@ def command_flash(args):
     logging.status("Flashing binar{} to board...".format(plural))
     tock_loader.flash_binary(binary, args.address, pad=pad)
 
+def command_debug(args):
+    # Check if binary exists
+    if not os.path.exists(args.binary):
+        raise TockLoaderException("{} does not exist".format(args.binary))
+
+    # For now, we do not compile or flash binary on the board
+
+    # Debug the binary to the chip
+    tock_loader = TockLoader(args)
+    tock_loader.open()
+
+    logging.status("Debug binary {} to board...".format(args.binary))
+    tock_loader.debug_binary(args.binary)
+
 
 def command_read(args):
     """
@@ -1055,6 +1069,16 @@ def main():
         help="List the boards that Tockloader explicitly knows about",
     )
     list_known_boards.set_defaults(func=command_list_known_boards)
+
+    debug_binary = subparser.add_parser(
+        "debug-binary",
+        parents=[parent, parent_channel],
+        help="Debug the binary installed on the board",
+    )
+    debug_binary.set_defaults(func=command_debug)
+    debug_binary.add_argument(
+        "--binary", help="The binary file or files to flash to the chip"
+    )
 
     argcomplete.autocomplete(parser)
     args, unknown_args = parser.parse_known_args()

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -1077,7 +1077,7 @@ def main():
     )
     debug_binary.set_defaults(func=command_debug)
     debug_binary.add_argument(
-        "--binary", help="The binary file or files to flash to the chip"
+        "--binary", help="The binary file to debug on the board"
     )
 
     argcomplete.autocomplete(parser)

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -713,6 +713,14 @@ class TockLoader:
         """
         BoardInterface(self.args).print_known_boards()
 
+    def debug_binary(self, binary):
+        """
+        Debug binary on board.
+        """
+        # Enter bootloader mode to get things started
+        with self._start_communication_with_board():
+            self.channel.debug(binary)
+
     ############################################################################
     ## Internal Helper Functions for Communicating with Boards
     ############################################################################
@@ -1440,10 +1448,3 @@ class TockLoader:
         else:
             # In quiet mode just show the names.
             print(" ".join([app.get_name() for app in apps]))
-
-    def debug_binary(self, binary):
-        """
-        """
-        # Enter bootloader mode to get things started
-        with self._start_communication_with_board():
-            self.channel.debug(binary)

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -1440,3 +1440,10 @@ class TockLoader:
         else:
             # In quiet mode just show the names.
             print(" ".join([app.get_name() for app in apps]))
+
+    def debug_binary(self, binary):
+        """
+        """
+        # Enter bootloader mode to get things started
+        with self._start_communication_with_board():
+            self.channel.debug(binary)


### PR DESCRIPTION
Hi,

This a command to support the "debug-binary" command in tockloader. This command allows to debug a binary on the board. It does not flash the binary on the board, only runs gdb and load a symbol file.

Since "--debug" would conflict with "debug", it is called "debug-binary". If it's a problem, we could rename "--debug" with "--verbose" to fix this issue.