### PR TITLE
Add support for TicKV

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ Set a specific field (by name) to the given value in a specific TLV (by ID).
 
 Remove a specific credential (by credential ID) from the TBF footer.
 
+#### `tockloader tickv get|append|invalidate|dump [key] [value]`
+
+Interact with a TicKV key-value database.
+
 
 Specifying the Board
 --------------------

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Set a specific field (by name) to the given value in a specific TLV (by ID).
 
 Remove a specific credential (by credential ID) from the TBF footer.
 
-#### `tockloader tickv get|append|invalidate|dump [key] [value]`
+#### `tockloader tickv get|append|invalidate|dump|cleanup|reset [key] [value]`
 
 Interact with a TicKV key-value database.
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "crcmod >= 1.7",
         "pycryptodome >= 3.15.0",
         "pyserial >= 3.0.1",
+        "siphash24 >= 1.3",
         "toml >= 0.10.2",
         "tqdm >= 4.45.0 ",
         "questionary >= 1.10.0",

--- a/tockloader/board_interface.py
+++ b/tockloader/board_interface.py
@@ -56,9 +56,14 @@ class BoardInterface:
             "no_attribute_table": True,
             "jlink": {
                 "device": "nrf52",
+                "address_maximum": 0x11FFFFFF,
             },
             "openocd": {
                 "cfg": "nordic_nrf52_dk.cfg",
+            },
+            "nrfjprog": {
+                "device_family": "NRF52",
+                "qspi_size": 1024 * 1024 * 64,
             },
         },
         "nano33ble": {

--- a/tockloader/exceptions.py
+++ b/tockloader/exceptions.py
@@ -4,3 +4,7 @@ class TockLoaderException(Exception):
     """
 
     pass
+
+
+class ChannelAddressErrorException(Exception):
+    pass

--- a/tockloader/exceptions.py
+++ b/tockloader/exceptions.py
@@ -7,4 +7,9 @@ class TockLoaderException(Exception):
 
 
 class ChannelAddressErrorException(Exception):
+    """
+    Raised when a particular channel to a board cannot support the request
+    operation, likely due to the specific address.
+    """
+
     pass

--- a/tockloader/jlinkexe.py
+++ b/tockloader/jlinkexe.py
@@ -19,7 +19,7 @@ import tempfile
 import time
 
 from .board_interface import BoardInterface
-from .exceptions import TockLoaderException
+from .exceptions import TockLoaderException, ChannelAddressErrorException
 
 
 class JLinkExe(BoardInterface):
@@ -35,6 +35,12 @@ class JLinkExe(BoardInterface):
             self.jlink_cmd = "JLinkExe"
             if platform.system() == "Windows":
                 self.jlink_cmd = "JLink"
+
+        # By default we assume that jlinkexe can be used to read any address on
+        # this board, so we set `address_maximum` to None. In some cases,
+        # however, particularly with external flash chips, jlinkexe may not be
+        # able to read all flash addresses tockloader needs to access.
+        self.address_maximum = None
 
     def attached_board_exists(self):
         # Get a list of attached jlink devices, check if that list has at least
@@ -120,6 +126,8 @@ class JLinkExe(BoardInterface):
                 self.jlink_if = board["jlink"]["if"]
             if self.jlink_speed == None and "speed" in board["jlink"]:
                 self.jlink_speed = board["jlink"]["speed"]
+            if self.address_maximum == None and "address_maximum" in board["jlink"]:
+                self.address_maximum = board["jlink"]["address_maximum"]
 
             # And we may need to setup other common board settings.
             self._configure_from_known_boards()
@@ -319,10 +327,13 @@ class JLinkExe(BoardInterface):
 
         return emulators
 
-    def flash_binary(self, address, binary):
+    def flash_binary(self, address, binary, pad=False):
         """
         Write using JTAG
         """
+        if self.address_maximum and address > self.address_maximum:
+            raise ChannelAddressErrorException()
+
         # Make sure we respect page boundaries in case the chip and jlink
         # implementation will only work correctly when writing entire pages.
         address, binary = self._align_and_stretch_to_page(address, binary)
@@ -337,6 +348,9 @@ class JLinkExe(BoardInterface):
         self._run_jtag_commands(commands, binary)
 
     def read_range(self, address, length):
+        if self.address_maximum and address > self.address_maximum:
+            raise ChannelAddressErrorException()
+
         commands = []
         if self.jlink_device == "cortex-m0":
             # We are in generic mode, trying to read attributes.
@@ -374,6 +388,9 @@ class JLinkExe(BoardInterface):
         return read
 
     def clear_bytes(self, address):
+        if self.address_maximum and address > self.address_maximum:
+            raise ChannelAddressErrorException()
+
         logging.debug("Clearing 512 bytes starting at address {:#0x}".format(address))
 
         # Write 512 bytes of 0xFF as that seems to work.

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -542,7 +542,7 @@ def command_tickv_append(args):
         with open(args.value_file, "rb") as f:
             append_bytes = f.read()
     else:
-        append_bytes = args.value[0].encode("utf-8")
+        append_bytes = args.value.encode("utf-8")
 
     tock_loader = TockLoader(args)
     tock_loader.open()

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -1116,14 +1116,22 @@ def main():
         "--tickv-file", help="The binary file containing the TicKV database"
     )
     parent_tickv.add_argument(
+        "--start-address",
+        help="Location in flash of the start of the TicKV database",
+        type=lambda x: int(x, 0),
+        default=-1,
+    )
+    parent_tickv.add_argument(
         "--region-size",
         help="Size in bytes of each TicKV region",
         type=lambda x: int(x, 0),
+        default=0,
     )
     parent_tickv.add_argument(
         "--number-regions",
         help="Number of regions in the TicKV database",
         type=lambda x: int(x, 0),
+        default=0,
     )
 
     tickv = subparser.add_parser(

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -529,6 +529,14 @@ def command_tickv_invalidate(args):
     tock_loader.tickv_invalidate(args.key)
 
 
+def command_tickv_append(args):
+    tock_loader = TockLoader(args)
+    tock_loader.open()
+
+    logging.status("Appending TicKV key...")
+    tock_loader.tickv_append(args.key, args.value)
+
+
 def command_list_known_boards(args):
     tock_loader = TockLoader(args)
     tock_loader.print_known_boards()
@@ -1138,6 +1146,21 @@ def main():
     tickv_invalidate.add_argument(
         "key",
         help="Key to invalidate from the TicKV database",
+    )
+
+    tickv_append = tickv_subparser.add_parser(
+        "append",
+        parents=[parent, parent_channel, parent_format, parent_tickv],
+        help="Add a key,value pair to a tickv database",
+    )
+    tickv_append.set_defaults(func=command_tickv_append)
+    tickv_append.add_argument(
+        "key",
+        help="Key to append from the TicKV database",
+    )
+    tickv_append.add_argument(
+        "value",
+        help="Value to append from the TicKV database",
     )
 
     argcomplete.autocomplete(parser)

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -537,6 +537,14 @@ def command_tickv_append(args):
     tock_loader.tickv_append(args.key, args.value)
 
 
+def command_tickv_cleanup(args):
+    tock_loader = TockLoader(args)
+    tock_loader.open()
+
+    logging.status("Cleaning TicKV database...")
+    tock_loader.tickv_cleanup()
+
+
 def command_tickv_reset(args):
     tock_loader = TockLoader(args)
     tock_loader.open()
@@ -1170,6 +1178,13 @@ def main():
         "value",
         help="Value to append from the TicKV database",
     )
+
+    tickv_cleanup = tickv_subparser.add_parser(
+        "cleanup",
+        parents=[parent, parent_channel, parent_format, parent_tickv],
+        help="Cleanup a tickv database by removing invalid objects",
+    )
+    tickv_cleanup.set_defaults(func=command_tickv_cleanup)
 
     tickv_reset = tickv_subparser.add_parser(
         "reset",

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -27,6 +27,7 @@ import crcmod
 from . import helpers
 from .exceptions import TockLoaderException
 from .tab import TAB
+from .tickv import TicKV
 from .tockloader import TockLoader
 from ._version import __version__
 
@@ -507,6 +508,20 @@ def command_dump_flash_page(args):
 def command_list_known_boards(args):
     tock_loader = TockLoader(args)
     tock_loader.print_known_boards()
+
+
+def command_tickv_dump(args):
+    database = b""
+    with open(args.tickv_file, "rb") as f:
+        database = f.read()
+
+    region_size = args.region_size
+    number_regions = args.number_regions
+
+    database = database[0 : region_size * number_regions]
+
+    tickv_db = TicKV(database, region_size)
+    print(tickv_db)
 
 
 ################################################################################
@@ -1057,6 +1072,25 @@ def main():
         help="List the boards that Tockloader explicitly knows about",
     )
     list_known_boards.set_defaults(func=command_list_known_boards)
+
+    tickv_dump = subparser.add_parser(
+        "tickv-dump",
+        help="Display a tickv database",
+    )
+    tickv_dump.set_defaults(func=command_tickv_dump)
+    tickv_dump.add_argument(
+        "tickv_file", help="The binary file containing the TicKV database"
+    )
+    tickv_dump.add_argument(
+        "region_size",
+        help="Size in bytes of each TicKV region",
+        type=lambda x: int(x, 0),
+    )
+    tickv_dump.add_argument(
+        "number_regions",
+        help="Number of regions in the TicKV database",
+        type=lambda x: int(x, 0),
+    )
 
     argcomplete.autocomplete(parser)
     args, unknown_args = parser.parse_known_args()

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -530,11 +530,25 @@ def command_tickv_invalidate(args):
 
 
 def command_tickv_append(args):
+    # We support appending a string from the command line or reading in a file
+    # and using its contents.
+    if args.value_file != None and args.value != None:
+        raise TockLoaderException(
+            "Cannot append both a string value and value from file"
+        )
+
+    append_bytes = b""
+    if args.value_file != None:
+        with open(args.value_file, "rb") as f:
+            append_bytes = f.read()
+    else:
+        append_bytes = args.value[0].encode("utf-8")
+
     tock_loader = TockLoader(args)
     tock_loader.open()
 
     logging.status("Appending TicKV key...")
-    tock_loader.tickv_append(args.key, args.value)
+    tock_loader.tickv_append(args.key, append_bytes)
 
 
 def command_tickv_cleanup(args):
@@ -1180,11 +1194,14 @@ def main():
     tickv_append.set_defaults(func=command_tickv_append)
     tickv_append.add_argument(
         "key",
-        help="Key to append from the TicKV database",
+        help="Key to append to the TicKV database",
     )
     tickv_append.add_argument(
-        "value",
-        help="Value to append from the TicKV database",
+        "value", help="Value to append to the TicKV database", nargs="?"
+    )
+    tickv_append.add_argument(
+        "--value-file",
+        help="Filepath of contents to append from the TicKV database",
     )
 
     tickv_cleanup = tickv_subparser.add_parser(

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -505,24 +505,15 @@ def command_dump_flash_page(args):
     tock_loader.dump_flash_page(args.page)
 
 
-def command_list_known_boards(args):
+def command_tickv_get(args):
     tock_loader = TockLoader(args)
-    tock_loader.print_known_boards()
+    tock_loader.open()
+
+    logging.status("Fetching TicKV key...")
+    tock_loader.tickv_get(args.key)
 
 
 def command_tickv_dump(args):
-    # database = b""
-    # with open(args.tickv_file, "rb") as f:
-    #     database = f.read()
-
-    # region_size = args.region_size
-    # number_regions = args.number_regions
-
-    # database = database[0 : region_size * number_regions]
-
-    # tickv_db = TockTicKV(database, region_size)
-    # print(tickv_db.dump())
-
     tock_loader = TockLoader(args)
     tock_loader.open()
 
@@ -530,27 +521,17 @@ def command_tickv_dump(args):
     tock_loader.tickv_dump()
 
 
-def command_tickv_get(args):
-    # database = b""
-    # with open(args.tickv_file, "rb") as f:
-    #     database = f.read()
-
-    # region_size = args.region_size
-    # number_regions = args.number_regions
-
-    # database = database[0 : region_size * number_regions]
-
-    # tickv_db = TockTicKV(database, region_size)
-
-    # tickv_db.invalidate(args.key)
-    # kv_object = tickv_db.get(args.key)
-    # print(kv_object)
-
+def command_tickv_invalidate(args):
     tock_loader = TockLoader(args)
     tock_loader.open()
 
-    logging.status("Fetching TicKV key...")
-    tock_loader.tickv_get(args.key)
+    logging.status("Invalidating TicKV key...")
+    tock_loader.tickv_invalidate(args.key)
+
+
+def command_list_known_boards(args):
+    tock_loader = TockLoader(args)
+    tock_loader.print_known_boards()
 
 
 ################################################################################
@@ -1147,6 +1128,17 @@ def main():
         help="Display the contents of a tickv database",
     )
     tickv_dump.set_defaults(func=command_tickv_dump)
+
+    tickv_invalidate = tickv_subparser.add_parser(
+        "invalidate",
+        parents=[parent, parent_channel, parent_format, parent_tickv],
+        help="Invalidate an item in a tickv database",
+    )
+    tickv_invalidate.set_defaults(func=command_tickv_invalidate)
+    tickv_invalidate.add_argument(
+        "key",
+        help="Key to invalidate from the TicKV database",
+    )
 
     argcomplete.autocomplete(parser)
     args, unknown_args = parser.parse_known_args()

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -537,6 +537,14 @@ def command_tickv_append(args):
     tock_loader.tickv_append(args.key, args.value)
 
 
+def command_tickv_reset(args):
+    tock_loader = TockLoader(args)
+    tock_loader.open()
+
+    logging.status("Resetting TicKV database...")
+    tock_loader.tickv_reset()
+
+
 def command_list_known_boards(args):
     tock_loader = TockLoader(args)
     tock_loader.print_known_boards()
@@ -1162,6 +1170,13 @@ def main():
         "value",
         help="Value to append from the TicKV database",
     )
+
+    tickv_reset = tickv_subparser.add_parser(
+        "reset",
+        parents=[parent, parent_channel, parent_format, parent_tickv],
+        help="Reset/erase a tickv database",
+    )
+    tickv_reset.set_defaults(func=command_tickv_reset)
 
     argcomplete.autocomplete(parser)
     args, unknown_args = parser.parse_known_args()

--- a/tockloader/nrfjprog.py
+++ b/tockloader/nrfjprog.py
@@ -1,0 +1,93 @@
+"""
+Interface for boards using nrfjprog.
+"""
+
+import logging
+import struct
+
+import pynrfjprog
+from pynrfjprog import HighLevel, Parameters
+
+from .board_interface import BoardInterface
+from .exceptions import TockLoaderException
+
+
+class nrfjprog(BoardInterface):
+    def __init__(self, args):
+        # Must call the generic init first.
+        super().__init__(args)
+
+    def open_link_to_board(self):
+
+        qspi_size = 0
+
+        # Get board-specific properties we need.
+        if self.board and self.board in self.KNOWN_BOARDS:
+            logging.info('Using settings from KNOWN_BOARDS["{}"]'.format(self.board))
+            board = self.KNOWN_BOARDS[self.board]
+
+            if "nrfjprog" in board:
+                if "qspi_size" in board["nrfjprog"]:
+                    qspi_size = board["nrfjprog"]["qspi_size"]
+
+        # pynrfjprog does a lot of logging, only turn that on in debug mode.
+        nrfjprog_logging = False
+        if self.args.debug:
+            nrfjprog_logging = True
+
+        # First create the base API, this is how pynrfjprog works.
+        api = pynrfjprog.HighLevel.API()
+        api.open()
+
+        # Need to provide the serial number of the board to connect to,
+        # easy enough to get. In the future maybe this would be specified.
+        serial_numbers = api.get_connected_probes()
+        if len(serial_numbers) == 0:
+            raise TockLoaderException("No nrfjprog device connected")
+
+        # Actually create the object we will use to read/write the board.
+        self.nrfjprog = pynrfjprog.HighLevel.DebugProbe(
+            api, serial_numbers[0], log=nrfjprog_logging
+        )
+
+        # Optionally setup the QSPI if we know its size.
+        if qspi_size > 0:
+            self.nrfjprog.setup_qspi(qspi_size)
+
+    def flash_binary(self, address, binary, pad=False):
+        """
+        Write using nrfjprog.
+        """
+
+        # We need to erase first, so make sure we are page aligned.
+        address, binary = self._align_and_stretch_to_page(address, binary)
+
+        # Erase before we can write.
+        self.nrfjprog.erase(
+            erase_action=pynrfjprog.Parameters.EraseAction.ERASE_SECTOR,
+            start_address=address,
+            end_address=address + len(binary),
+        )
+
+        # Write word by word because there seems to be an issue with writing
+        # buffers: https://devzone.nordicsemi.com/f/nordic-q-a/100613/pynrfjprog-using-pynrfjprog-to-write-qspi-with-buffer-writes-wrong-data
+        for i in range(0, len(binary), 4):
+            word = struct.unpack("<I", binary[i : i + 4])[0]
+
+            # Skip writing all 0xff since the flash is already erased.
+            if word == 0xFFFFFFFF:
+                continue
+
+            self.nrfjprog.write(address=address + i, data=word)
+
+    def read_range(self, address, length):
+        """
+        Read using nrfjprog.
+        """
+        return self.nrfjprog.read(address=address, data_len=length)
+
+    def clear_bytes(self, address):
+        logging.debug("Clearing bytes starting at {:#0x}".format(address))
+
+        binary = bytes([0xFF] * 8)
+        self.flash_binary(address, binary)

--- a/tockloader/nrfjprog.py
+++ b/tockloader/nrfjprog.py
@@ -18,7 +18,6 @@ class nrfjprog(BoardInterface):
         super().__init__(args)
 
     def open_link_to_board(self):
-
         qspi_size = 0
 
         # Get board-specific properties we need.

--- a/tockloader/openocd.py
+++ b/tockloader/openocd.py
@@ -280,7 +280,7 @@ You may need to update OpenOCD to the version in latest git master."
 
         return emulators
 
-    def flash_binary(self, address, binary):
+    def flash_binary(self, address, binary, pad=False):
         """
         Write using openocd `program` command.
         """

--- a/tockloader/tbfh.py
+++ b/tockloader/tbfh.py
@@ -7,7 +7,7 @@ import traceback
 import Crypto
 from Crypto.Signature import pkcs1_15
 from Crypto.PublicKey import RSA
-from Crypto.Hash import SHA512
+from Crypto.Hash import SHA512, SHA256
 
 from .exceptions import TockLoaderException
 

--- a/tockloader/tickv.py
+++ b/tockloader/tickv.py
@@ -1,4 +1,9 @@
+"""
+Manage and use a TicKV formatted database.
+"""
+
 import binascii
+import logging
 import struct
 
 import zlib
@@ -9,6 +14,97 @@ import siphash24
 from .exceptions import TockLoaderException
 
 
+class TicKVObjectHeader:
+    def __init__(self, version, flags, hashed_key):
+        self.version = version
+        self.flags = flags
+        self.hashed_key = hashed_key
+
+    def length(self):
+        return 11
+
+    def invalidate(self):
+        self.flags &= 0x7
+
+    def is_valid(self):
+        return (self.flags >> 3) & 0x1 == 0x1
+
+    def get_binary(self, length):
+        flags_length = (self.flags << 12) | length
+        return struct.pack(">BHQ", self.version, flags_length, self.hashed_key)
+
+
+class TicKVObject:
+    def __init__(self, header, value_buffer, checksum):
+        self.header = header
+        self.value_buffer = value_buffer
+        self.checksum = checksum
+
+    def length(self):
+        """
+        Return the total length of this object in the database in bytes.
+        """
+        # Size is header length + value length + checksum length (4)
+        return self.header.length() + len(self.value_buffer) + 4
+
+    def invalidate(self):
+        self.header.invalidate()
+
+    def get_header(self):
+        return self.header
+
+    def get_hashed_key(self):
+        return self.header.hashed_key
+
+    def get_checksum(self):
+        return self.checksum
+
+    def get_value_bytes(self):
+        return self.value_buffer
+
+    def get_binary(self):
+        return bytearray(
+            self.header.get_binary(self.length())
+            + self.value_buffer
+            + struct.pack("<I", self.checksum)
+        )
+
+    def __str__(self):
+        out = ""
+        out += "TicKV Object version={} flags={} length={} checksum={:#x}\n".format(
+            self.header.version, self.header.flags, self.length(), self.checksum
+        )
+        v = binascii.hexlify(self.value_buffer).decode("utf-8")
+        out += "  Value: {}\n".format(v)
+
+        return out
+
+
+class TockTicKVObject:
+    def __init__(self, header, checksum, version, write_id, value_buffer):
+        self.header = header
+        self.value_buffer = value_buffer
+        self.checksum = checksum
+        self.version = version
+        self.write_id = write_id
+
+    def __str__(self):
+        out = ""
+        out += "TicKV Object version={} flags={} valid={} checksum={:#x}\n".format(
+            self.header.version,
+            self.header.flags,
+            self.header.is_valid(),
+            self.checksum,
+        )
+        out += "  TockTicKV Object version={} write_id={} length={}\n".format(
+            self.version, self.write_id, len(self.value_buffer)
+        )
+        v = binascii.hexlify(self.value_buffer).decode("utf-8")
+        out += "    Value: {}\n".format(v)
+
+        return out
+
+
 class TicKV:
     def __init__(self, storage_binary, region_size):
         """
@@ -16,16 +112,12 @@ class TicKV:
         the storage.
         """
 
-        # ///     poly: 0x04c11db7
-        # ///     init: 0x00000000
-        # ///     refin: false
-        # ///     refout: false
-        # ///     xorout: 0xffffffff
-
+        # These arguments don't exactly match (init should be 0), but the actual
+        # CRC values seem to work.
         self.crc_fn = crcmod.mkCrcFun(
             poly=0x104C11DB7, rev=False, initCrc=0xFFFFFFFF, xorOut=0xFFFFFFFF
         )
-        self.storage_binary = storage_binary
+        self.storage_binary = bytearray(storage_binary)
         self.region_size = region_size
 
         # The storage binary must be a multiple of the region size for the storage to be valid.
@@ -37,89 +129,90 @@ class TicKV:
     def _get_number_regions(self):
         return len(self.storage_binary) // self.region_size
 
-    def _hash_key(self, key):
-        key_buffer = key.encode("utf-8")
-        key_buffer += b"\0" * (64 - len(key_buffer))
-        h = siphash24.siphash24()
-        h.update(data=key_buffer)
-        return h.digest()
-
-    def trial(self):
-        key = "tickv-super-key"
-        return self._hash_key(key)
-
-    def parse_region(self, region_index):
-        region_binary = self.storage_binary[
+    def _get_region_binary(self, region_index):
+        return self.storage_binary[
             region_index * self.region_size : (region_index + 1) * self.region_size
         ]
 
-        objects = []
+    def _update_region_binary(self, region_index, region_binary):
+        self.storage_binary[
+            region_index * self.region_size : (region_index + 1) * self.region_size
+        ] = region_binary
 
-        print("REGION {}".format(region_index))
+    def _parse_object(self, buffer):
+        object_header_bytes = buffer[0:11]
+        object_header_fields = struct.unpack(">BHQ", object_header_bytes)
+
+        version = object_header_fields[0]
+        flags = object_header_fields[1] >> 12
+        length = object_header_fields[1] & 0xFFF
+        hashed_key = object_header_fields[2]
+
+        if version != 1:
+            return None
+
+        header = TicKVObjectHeader(version, flags, hashed_key)
+
+        value_length = length - 11 - 4
+        object_value_bytes = buffer[11 : 11 + value_length]
+        object_checksum_bytes = buffer[length - 4 : length]
+        object_checksum = struct.unpack("<I", object_checksum_bytes)[0]
+
+        return TicKVObject(header, object_value_bytes, object_checksum)
+
+    def get(self, hashed_key):
+        region_index = (hashed_key & 0xFFFF) % self._get_number_regions()
+        region_binary = self._get_region_binary(region_index)
 
         offset = 0
         while True:
+            kv_object = self._parse_object(region_binary[offset:])
 
-            object_header_bytes = region_binary[offset : offset + 11]
-            object_header_fields = struct.unpack(
-                ">BH8s", region_binary[offset : offset + 11]
-            )
-            object_header = {
-                "version": object_header_fields[0],
-                "flags": object_header_fields[1] >> 12,
-                "len": object_header_fields[1] & 0xFFF,
-                "hashed_key": object_header_fields[2],
-            }
-            offset += 11
+            if kv_object == None:
+                break
 
-            if object_header["version"] == 1:
-                value_length = object_header["len"] - 11 - 4
-                object_value_bytes = region_binary[offset : offset + value_length]
-                offset += value_length
-                object_checksum = region_binary[offset : offset + 4]
-                offset += 4
+            if kv_object.get_hashed_key() != hashed_key:
+                offset += kv_object.length()
+                continue
 
-                if len(object_value_bytes) > 9:
-                    kv_tock_header_fields = struct.unpack(
-                        "<BII", object_value_bytes[0:9]
-                    )
-                    object_value = {
-                        "version": kv_tock_header_fields[0],
-                        "length": kv_tock_header_fields[1],
-                        "write_id": kv_tock_header_fields[2],
-                    }
-                    object_value["value"] = object_value_bytes[
-                        9 : 9 + object_value["length"]
-                    ]
-                else:
-                    object_value = {
-                        "value": object_value_bytes,
-                    }
+            return kv_object
 
-                objects.append(
-                    {
-                        "header": object_header,
-                        "value": object_value,
-                        "checksum": object_checksum,
-                        "calculated_checksum": self.crc_fn(
-                            object_header_bytes + object_value_bytes
-                        ),
-                    }
-                )
+    def get_all(self, region_index):
+        region_binary = self._get_region_binary(region_index)
+
+        kv_objects = []
+
+        offset = 0
+        while True:
+            kv_object = self._parse_object(region_binary[offset:])
+            if kv_object != None:
+                kv_objects.append(kv_object)
+                offset += kv_object.length()
             else:
                 break
 
-        for o in objects:
-            print(o["header"])
-            print(binascii.hexlify(o["header"]["hashed_key"]).decode("utf-8"))
-            print(o["value"])
-            print(binascii.hexlify(o["value"]["value"]).decode("utf-8"))
-            print(binascii.hexlify(o["checksum"]).decode("utf-8"))
-            print(
-                binascii.hexlify(o["calculated_checksum"].to_bytes(4, "little")).decode(
-                    "utf-8"
-                )
-            )
+        return kv_objects
+
+    def invalidate(self, hashed_key):
+        region_index = (hashed_key & 0xFFFF) % self._get_number_regions()
+        region_binary = self._get_region_binary(region_index)
+
+        offset = 0
+        while True:
+            kv_object = self._parse_object(region_binary[offset:])
+
+            if kv_object == None:
+                break
+
+            if kv_object.get_hashed_key() == hashed_key:
+                length = kv_object.length()
+                kv_object.invalidate()
+                updated_object_binary = kv_object.get_binary()
+                for i in range(0, length):
+                    region_binary[offset + i] = updated_object_binary[i]
+                break
+
+        self._update_region_binary(region_index, region_binary)
 
     def __str__(self):
         out = "\n"
@@ -131,4 +224,101 @@ class TicKV:
 
         for i in range(0, self._get_number_regions()):
             self.parse_region(i)
+        return out
+
+
+class TockTicKV(TicKV):
+    """
+    Extension of a TicKV database that adds an additional header with a
+    `write_id` to enable enforcing access control.
+    """
+
+    def _hash_key(self, key):
+        """
+        Compute the SipHash24 for the given key. We always pad the key to
+        be 64 bytes by adding zeros.
+        """
+
+        key_buffer = key.encode("utf-8")
+        key_buffer += b"\0" * (64 - len(key_buffer))
+        h = siphash24.siphash24()
+        h.update(data=key_buffer)
+        return h.digest()
+
+    def _hash_key_int(self, key):
+        """
+        Compute the SipHash24 for the given key. Return as u64.
+        """
+
+        hashed_key_buf = self._hash_key(key)
+        return struct.unpack(">Q", hashed_key_buf)[0]
+
+    def _parse_tock_object(self, kv_object):
+        if len(kv_object.get_value_bytes()) >= 9:
+            kv_tock_header_fields = struct.unpack(
+                "<BII", kv_object.get_value_bytes()[0:9]
+            )
+            version = kv_tock_header_fields[0]
+            length = kv_tock_header_fields[1]
+            write_id = kv_tock_header_fields[2]
+
+            value_bytes = kv_object.get_value_bytes()[9 : 9 + length]
+
+            tock_kv_object = TockTicKVObject(
+                kv_object.get_header(),
+                kv_object.get_checksum(),
+                version,
+                write_id,
+                value_bytes,
+            )
+
+            return tock_kv_object
+        else:
+            return None
+
+    def get(self, key):
+        logging.debug('Finding key "{}" in Tock-style TicKV database.'.format(key))
+
+        hashed_key = self._hash_key_int(key)
+
+        kv_object = super().get(hashed_key)
+        if kv_object == None:
+            return None
+
+        return self._parse_tock_object(kv_object)
+
+    def get_all(self, region_index):
+        logging.debug(
+            "Finding all objects in region {} of a Tock-style TicKV database.".format(
+                region_index
+            )
+        )
+
+        kv_objects = super().get_all(region_index)
+
+        tock_kv_objects = []
+        for kv_object in kv_objects:
+            tock_kv_object = self._parse_tock_object(kv_object)
+            if tock_kv_object != None:
+                tock_kv_objects.append(tock_kv_object)
+
+        return tock_kv_objects
+
+    def invalidate(self, key):
+        hashed_key = self._hash_key_int(key)
+        super().invalidate(hashed_key)
+
+    def dump(self):
+        logging.info("Dumping entire contents of Tock-style TicKV database.")
+
+        out = ""
+        for region_index in range(0, self._get_number_regions()):
+            tock_kv_objects = self.get_all(region_index)
+
+            out += "REGION {}\n".format(region_index)
+            for tock_kv_object in tock_kv_objects:
+                out += str(tock_kv_object)
+
+            out += "\n"
+
         return out

--- a/tockloader/tickv.py
+++ b/tockloader/tickv.py
@@ -1,5 +1,7 @@
 """
 Manage and use a TicKV formatted database.
+
+TicKV: https://github.com/tock/tock/tree/master/libraries/tickv
 """
 
 import binascii

--- a/tockloader/tickv.py
+++ b/tockloader/tickv.py
@@ -6,8 +6,6 @@ import binascii
 import logging
 import struct
 
-import zlib
-
 import crcmod
 import siphash24
 
@@ -277,7 +275,7 @@ class TockTicKV(TicKV):
             return None
 
     def get(self, key):
-        logging.debug('Finding key "{}" in Tock-style TicKV database.'.format(key))
+        logging.info('Finding key "{}" in Tock-style TicKV database.'.format(key))
 
         hashed_key = self._hash_key_int(key)
 
@@ -288,12 +286,6 @@ class TockTicKV(TicKV):
         return self._parse_tock_object(kv_object)
 
     def get_all(self, region_index):
-        logging.debug(
-            "Finding all objects in region {} of a Tock-style TicKV database.".format(
-                region_index
-            )
-        )
-
         kv_objects = super().get_all(region_index)
 
         tock_kv_objects = []

--- a/tockloader/tickv.py
+++ b/tockloader/tickv.py
@@ -246,7 +246,6 @@ class TicKVObjectTock(TicKVObjectBase):
 
 class TicKVObjectTockFlash(TicKVObjectTock):
     def __init__(self, tickv_object):
-
         value_bytes = tickv_object.get_value_bytes()
         storage_object = TockStorageObjectFlash(value_bytes)
         padding = len(value_bytes) - storage_object.length()

--- a/tockloader/tickv.py
+++ b/tockloader/tickv.py
@@ -535,7 +535,9 @@ class TockTicKV(TicKV):
         logging.info("Appending TockTicKV object {}={}".format(key, value))
         hashed_key = self._hash_key_int(key)
         header = TicKVObjectHeader(hashed_key)
-        storage_object = TockStorageObject(value.encode("utf-8"))
+        if isinstance(value, str):
+            value = value.encode("utf-8")
+        storage_object = TockStorageObject(value)
         tock_kv_object = TicKVObjectTock(header, storage_object)
 
         super()._append_object(tock_kv_object)

--- a/tockloader/tickv.py
+++ b/tockloader/tickv.py
@@ -1,0 +1,134 @@
+import binascii
+import struct
+
+import zlib
+
+import crcmod
+import siphash24
+
+from .exceptions import TockLoaderException
+
+
+class TicKV:
+    def __init__(self, storage_binary, region_size):
+        """
+        Create a new TicKV object with a given binary buffer representing
+        the storage.
+        """
+
+        # ///     poly: 0x04c11db7
+        # ///     init: 0x00000000
+        # ///     refin: false
+        # ///     refout: false
+        # ///     xorout: 0xffffffff
+
+        self.crc_fn = crcmod.mkCrcFun(
+            poly=0x104C11DB7, rev=False, initCrc=0xFFFFFFFF, xorOut=0xFFFFFFFF
+        )
+        self.storage_binary = storage_binary
+        self.region_size = region_size
+
+        # The storage binary must be a multiple of the region size for the storage to be valid.
+        if len(self.storage_binary) % self.region_size != 0:
+            raise TockLoaderException(
+                "ERROR: TicKV storage not a multiple of region size."
+            )
+
+    def _get_number_regions(self):
+        return len(self.storage_binary) // self.region_size
+
+    def _hash_key(self, key):
+        key_buffer = key.encode("utf-8")
+        key_buffer += b"\0" * (64 - len(key_buffer))
+        h = siphash24.siphash24()
+        h.update(data=key_buffer)
+        return h.digest()
+
+    def trial(self):
+        key = "tickv-super-key"
+        return self._hash_key(key)
+
+    def parse_region(self, region_index):
+        region_binary = self.storage_binary[
+            region_index * self.region_size : (region_index + 1) * self.region_size
+        ]
+
+        objects = []
+
+        print("REGION {}".format(region_index))
+
+        offset = 0
+        while True:
+
+            object_header_bytes = region_binary[offset : offset + 11]
+            object_header_fields = struct.unpack(
+                ">BH8s", region_binary[offset : offset + 11]
+            )
+            object_header = {
+                "version": object_header_fields[0],
+                "flags": object_header_fields[1] >> 12,
+                "len": object_header_fields[1] & 0xFFF,
+                "hashed_key": object_header_fields[2],
+            }
+            offset += 11
+
+            if object_header["version"] == 1:
+                value_length = object_header["len"] - 11 - 4
+                object_value_bytes = region_binary[offset : offset + value_length]
+                offset += value_length
+                object_checksum = region_binary[offset : offset + 4]
+                offset += 4
+
+                if len(object_value_bytes) > 9:
+                    kv_tock_header_fields = struct.unpack(
+                        "<BII", object_value_bytes[0:9]
+                    )
+                    object_value = {
+                        "version": kv_tock_header_fields[0],
+                        "length": kv_tock_header_fields[1],
+                        "write_id": kv_tock_header_fields[2],
+                    }
+                    object_value["value"] = object_value_bytes[
+                        9 : 9 + object_value["length"]
+                    ]
+                else:
+                    object_value = {
+                        "value": object_value_bytes,
+                    }
+
+                objects.append(
+                    {
+                        "header": object_header,
+                        "value": object_value,
+                        "checksum": object_checksum,
+                        "calculated_checksum": self.crc_fn(
+                            object_header_bytes + object_value_bytes
+                        ),
+                    }
+                )
+            else:
+                break
+
+        for o in objects:
+            print(o["header"])
+            print(binascii.hexlify(o["header"]["hashed_key"]).decode("utf-8"))
+            print(o["value"])
+            print(binascii.hexlify(o["value"]["value"]).decode("utf-8"))
+            print(binascii.hexlify(o["checksum"]).decode("utf-8"))
+            print(
+                binascii.hexlify(o["calculated_checksum"].to_bytes(4, "little")).decode(
+                    "utf-8"
+                )
+            )
+
+    def __str__(self):
+        out = "\n"
+        k = binascii.hexlify(self.trial()).decode("utf-8")
+        out += "{}\n".format(k)
+
+        k = binascii.hexlify(self._hash_key("mythirdkey")).decode("utf-8")
+        out += "{}\n".format(k)
+
+        for i in range(0, self._get_number_regions()):
+            self.parse_region(i)
+        return out

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -717,21 +717,28 @@ class TockLoader:
 
     def tickv_dump(self):
         """
-        Read a key, value pair from a TicKV database on a board.
+        Display all of the contents of a TicKV database.
         """
-
         with self._start_communication_with_board():
             tickv_db = self._tickv_get_database()
             print(tickv_db.dump())
 
     def tickv_invalidate(self, key):
         """
-        Read a key, value pair from a TicKV database on a board.
+        Invalidate a particular key in the database.
         """
-
         with self._start_communication_with_board():
             tickv_db = self._tickv_get_database()
             tickv_db.invalidate(key)
+            self._tickv_write_database(tickv_db)
+
+    def tickv_append(self, key, value):
+        """
+        Add a key,value pair to the database.
+        """
+        with self._start_communication_with_board():
+            tickv_db = self._tickv_get_database()
+            tickv_db.append(key, value)
             self._tickv_write_database(tickv_db)
 
     def run_terminal(self):

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -761,6 +761,15 @@ class TockLoader:
             tickv_db.append(key, value)
             self._tickv_write_database(tickv_db)
 
+    def tickv_reset(self):
+        """
+        Reset the database by erasing it and re-initializing.
+        """
+        with self._start_communication_with_board():
+            tickv_db = self._tickv_get_database()
+            tickv_db.reset()
+            self._tickv_write_database(tickv_db)
+
     def run_terminal(self):
         """
         Create an interactive terminal session with the board.

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -1092,6 +1092,7 @@ class TockLoader:
             tickv_address = self.app_settings["tickv"]["start_address"]
 
         try:
+            logging.info("Writing TicKV database back to flash")
             tickv_db = self.channel.flash_binary(tickv_address, tickv_db.get_binary())
         except ChannelAddressErrorException:
             try:

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -761,6 +761,16 @@ class TockLoader:
             tickv_db.append(key, value)
             self._tickv_write_database(tickv_db)
 
+    def tickv_cleanup(self):
+        """
+        Clean the database by remove invalid objects and re-storing valid
+        objects.
+        """
+        with self._start_communication_with_board():
+            tickv_db = self._tickv_get_database()
+            tickv_db.cleanup()
+            self._tickv_write_database(tickv_db)
+
     def tickv_reset(self):
         """
         Reset the database by erasing it and re-initializing.

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -28,7 +28,6 @@ from .exceptions import TockLoaderException, ChannelAddressErrorException
 from .tbfh import TBFHeader
 from .tbfh import TBFFooter
 from .jlinkexe import JLinkExe
-from .nrfjprog import nrfjprog
 from .openocd import OpenOCD, collect_temp_files
 from .flash_file import FlashFile
 from .tickv import TockTicKV
@@ -668,6 +667,13 @@ class TockLoader:
             try:
                 flash = self.channel.read_range(address, page_size)
             except ChannelAddressErrorException:
+                try:
+                    from .nrfjprog import nrfjprog
+                except:
+                    logging.error("Unable to use backup nrfjprog channel")
+                    logging.error("You may need to `pip install pynrfjprog`")
+                    raise TockLoaderException("Unable to use nrfjprog backup channel")
+
                 self.args.board = self.channel.get_board_name()
                 backup_channel = nrfjprog(self.args)
                 backup_channel.open_link_to_board()
@@ -683,6 +689,13 @@ class TockLoader:
             try:
                 flash = self.channel.read_range(address, length)
             except ChannelAddressErrorException:
+                try:
+                    from .nrfjprog import nrfjprog
+                except:
+                    logging.error("Unable to use backup nrfjprog channel")
+                    logging.error("You may need to `pip install pynrfjprog`")
+                    raise TockLoaderException("Unable to use nrfjprog backup channel")
+
                 self.args.board = self.channel.get_board_name()
                 backup_channel = nrfjprog(self.args)
                 backup_channel.open_link_to_board()

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -713,6 +713,13 @@ class TockLoader:
             try:
                 self.channel.flash_binary(address, to_write, pad=False)
             except ChannelAddressErrorException:
+                try:
+                    from .nrfjprog import nrfjprog
+                except:
+                    logging.error("Unable to use backup nrfjprog channel")
+                    logging.error("You may need to `pip install pynrfjprog`")
+                    raise TockLoaderException("Unable to use nrfjprog backup channel")
+
                 self.args.board = self.channel.get_board_name()
                 backup_channel = nrfjprog(self.args)
                 backup_channel.open_link_to_board()
@@ -1026,6 +1033,13 @@ class TockLoader:
         try:
             tickv_db = self.channel.read_range(ticvk_address, tickv_size)
         except ChannelAddressErrorException:
+            try:
+                from .nrfjprog import nrfjprog
+            except:
+                logging.error("Unable to use backup nrfjprog channel")
+                logging.error("You may need to `pip install pynrfjprog`")
+                raise TockLoaderException("Unable to use nrfjprog backup channel")
+
             self.args.board = self.channel.get_board_name()
             backup_channel = nrfjprog(self.args)
             backup_channel.open_link_to_board()
@@ -1045,6 +1059,13 @@ class TockLoader:
         try:
             tickv_db = self.channel.flash_binary(ticvk_address, tickv_db.get_binary())
         except ChannelAddressErrorException:
+            try:
+                from .nrfjprog import nrfjprog
+            except:
+                logging.error("Unable to use backup nrfjprog channel")
+                logging.error("You may need to `pip install pynrfjprog`")
+                raise TockLoaderException("Unable to use nrfjprog backup channel")
+
             self.args.board = self.channel.get_board_name()
             backup_channel = nrfjprog(self.args)
             backup_channel.open_link_to_board()

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -752,13 +752,21 @@ class TockLoader:
             tickv_db.invalidate(key)
             self._tickv_write_database(tickv_db)
 
-    def tickv_append(self, key, value):
+    def tickv_append(self, key, value=None):
         """
-        Add a key,value pair to the database.
+        Add a key,value pair to the database. The first argument can a list of
+        key, value pairs.
         """
         with self._start_communication_with_board():
             tickv_db = self._tickv_get_database()
-            tickv_db.append(key, value)
+
+            # Check if we got a list of key-value pairs or just one.
+            if isinstance(key, list):
+                for k, v in key:
+                    tickv_db.append(k, v)
+            else:
+                tickv_db.append(key, value)
+
             self._tickv_write_database(tickv_db)
 
     def tickv_cleanup(self):


### PR DESCRIPTION
This allows tockloader to interact with a tickv database.

Just like any tockloader operation, this can work on a board, or with a local binary file.

I don't know how to find the tickv database so instead the settings are hardcoded in tockloader.

Example:

```
$ tockloader tickv append testkey testval --board tickv --flash-file tickv.bin
$ tockloader tickv get testkey --board tickv --flash-file tickv.bin
```