### PR TITLE
board_interface: add OpenTitan EarlGrey chip to KNOWN_BOARDS

### DIFF
--- a/tockloader/board_interface.py
+++ b/tockloader/board_interface.py
@@ -289,6 +289,17 @@ class BoardInterface:
                 "device": "nrf52",
             },
         },
+        "opentitan_earlgrey": {
+            "description": "OpenTitan EarlGrey chip targeting the Earlgrey-M2.5.2-RC0 hardware",
+            "arch": "rv32imc",
+            "page_size": 512,
+            "no_attribute_table": True,
+            "address_translator": lambda addr: addr - 0x20000000,
+            "flash_file": {
+                # Set to the maximum flash size.
+                "max_size": 0x00100000,
+            },
+        },
     }
 
     def __init__(self, args):


### PR DESCRIPTION
This adds an entry to `KNOWN_BOARDS` for the OpenTitan EarlGrey chip, targeting the Earlgrey-M2.5.2-RC0 hardware revision to be taped out. While not supported with any board interface (potentially `opentitantool` could be supported in the future), the flash-file backed allows using Tockloader to place non-PIC TBFs into a flash image. This can then be used to bootstrap a compatible FPGA bitstream or Verilator simulation.

This was tested to place a TBF binary at the correct offset in an image.