### PR TITLE
tockloader: support TBFs with fixed flash addr but non-fixed RAM addr

### DIFF
--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -1163,8 +1163,17 @@ class TockLoader:
         # Get where app memory might start.
         ram_start_address = self._get_memory_start_address()
 
+        # elf2tab can produce TBFs which have a fixed flash start
+        # address, but not a fixed RAM start address, in which case
+        # the above is `None`. Preformat it in case it is a number,
+        # otherwise print as "None":
+        if ram_start_address is None:
+            ram_start_address_hex = "None"
+        else:
+            ram_start_address_hex = "{:#x}".format(ram_start_address)
+
         logging.debug(
-            "Shuffling apps. Flash={:#x} RAM={:#x}".format(address, ram_start_address)
+            "Shuffling apps. Flash={:#x} RAM={}".format(address, ram_start_address_hex)
         )
 
         # First, we are going to split the work into three cases:


### PR DESCRIPTION
elf2tab can produce TBFs which have a fixed flash start address, but not a fixed RAM start address, in which case the above is `None`. Preformat it in case it is a number, otherwise print as "None". The `{:#x}` format string breaks on `None` with the following runtime exception:

    Traceback (most recent call last):
      File "/home/leons/.local/bin/tockloader", line 8, in <module>
        sys.exit(main())
      File "/home/leons/dev/tockloader/tockloader/main.py", line 1444, in main
        args.func(args)
      File "/home/leons/dev/tockloader/tockloader/main.py", line 153, in command_install
        tock_loader.install(tabs, replace=replace, erase=args.erase, sticky=args.sticky)
      File "/home/leons/dev/tockloader/tockloader/tockloader.py", line 375, in install
        self._reshuffle_apps(resulting_apps)
      File "/home/leons/dev/tockloader/tockloader/tockloader.py", line 1168, in _reshuffle_apps
        "Shuffling apps. Flash={:#x} RAM={:#x}".format(address, ram_start_address)
    TypeError: unsupported format string passed to NoneType.__format__