### PR TITLE
default.nix: mark packages as unfree and other fixes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -31,7 +31,7 @@ let
     meta.license = lib.licenses.unfree;
   };
 
-  pythonPackages = lib.fix' (self: with self; pkgs.python3Packages //
+  python3Packages = lib.fix' (self: with self; pkgs.python3Packages //
   {
     siphash = buildPythonPackage rec {
       pname = "siphash";
@@ -77,7 +77,7 @@ in pkgs.python3Packages.buildPythonPackage rec {
   version = "1.10.0";
   name = "${pname}-${version}";
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with python3Packages; [
     argcomplete
     colorama
     crcmod

--- a/default.nix
+++ b/default.nix
@@ -93,4 +93,10 @@ in pkgs.python3Packages.buildPythonPackage rec {
 
   # Dependency checks require unfree software
   doCheck = withUnfreePkgs;
+
+  # Make other dependencies explicitly available as passthru attributes
+  passthru = {
+    inherit nrf-command-line-tools;
+    pynrfjprog = python3Packages.pynrfjprog;
+  };
 }

--- a/default.nix
+++ b/default.nix
@@ -27,6 +27,8 @@ let
       mkdir -p $out/
       cp -r * $out/
     '';
+
+    meta.license = lib.licenses.unfree;
   };
 
   pythonPackages = lib.fix' (self: with self; pkgs.python3Packages //
@@ -66,6 +68,8 @@ let
         tomli-w
         future
       ];
+
+      meta.license = lib.licenses.unfree;
     };
   });
 in pkgs.python3Packages.buildPythonPackage rec {


### PR DESCRIPTION
This adds a couple of small fixes / changes to the `default.nix` Nix expression, namely:
- it marks unfree packages as actually unfree.
- it renames `pythonPackages` to `python3Packages`. `pythonPackages` would otherwise point to the Python 2.7 package set in this scope, which is confusing.
- it exposes the useful (but unfree) intermediate package definitions such as `nrf-command-line-tools` or `pynrfjprog` through the `passthru` attribute, such that they can be used in other Nix expressions, like `libtock-c`'s.