### PR TITLE
TBF footer: ignore trailing padding.

### DIFF
--- a/tockloader/tbfh.py
+++ b/tockloader/tbfh.py
@@ -1837,9 +1837,11 @@ class TBFFooter:
         else:
             integrity_blob = None
 
-        # Iterate all TLVs and add to list.
-        position = 0
-        while position < len(buffer):
+        # Iterate all TLVs and add to list. During the iteration, we modify
+        # `buffer` to refer to the remaining unprocessed bytes.
+        # If len(buffer) is 1-3, that means it consists entirely of trailing
+        # padding.
+        while len(buffer) >= 4:
             base = struct.unpack("<HH", buffer[0:4])
             buffer = buffer[4:]
             tlv_type = base[0]


### PR DESCRIPTION
Tockloader was trying to parse trailing padding as a TLV entry, resulting in a crash (#105). This change makes the parsing loop stop when fewer than 4 bytes remain in the buffer, at which point the remainder of the buffer should be padding bytes.