### PR TITLE
particle_boron: fixup app start_address

### DIFF
--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -116,6 +116,9 @@ class TockLoader:
                     "start_address": 0x12000000,
                 },
             },
+            "particle_boron": {
+                "start_address": 0x40000,
+            },
             "nucleof4": {"start_address": 0x08040000},
             "microbit_v2": {"start_address": 0x00040000},
             "qemu_rv32_virt": {"start_address": 0x80100000},


### PR DESCRIPTION
## Summary

For the nrf52840 (used in the particle boron), the current layout from
`nrf52840_chip_layout.ld` states that program memory starts at `0x4000`. This change ensures that we load apps at the correct address.

## Fixes

This fixes a bug where apps are `loaded` by tockloader but not actual run or detected on this board.