### PR TITLE
openocd: finer-grained error msg if board unknown

### DIFF
--- a/tockloader/openocd.py
+++ b/tockloader/openocd.py
@@ -370,21 +370,15 @@ You may need to update OpenOCD to the version in latest git master."
 
         # Check that we learned what we needed to learn.
         if self.board is None:
-            raise TockLoaderException(
-                "Could not determine the current board"
-            )
+            raise TockLoaderException("Could not determine the current board")
         if self.arch is None:
-            raise TockLoaderException(
-                "Could not determine the current arch"
-            )
+            raise TockLoaderException("Could not determine the current arch")
         if self.openocd_board == "cortex-m0":
             raise TockLoaderException(
                 "Could not determine the current openocd board name"
             )
         if self.page_size == 0:
-            raise TockLoaderException(
-                "Could not determine the current page size"
-            )
+            raise TockLoaderException("Could not determine the current page size")
 
     def run_terminal(self):
         self.open_link_to_board()

--- a/tockloader/openocd.py
+++ b/tockloader/openocd.py
@@ -369,14 +369,21 @@ You may need to update OpenOCD to the version in latest git master."
         self._configure_from_known_boards()
 
         # Check that we learned what we needed to learn.
-        if (
-            self.board == None
-            or self.arch == None
-            or self.openocd_board == "cortex-m0"
-            or self.page_size == 0
-        ):
+        if self.board is None:
             raise TockLoaderException(
-                "Could not determine the current board or arch or openocd board name"
+                "Could not determine the current board"
+            )
+        if self.arch is None:
+            raise TockLoaderException(
+                "Could not determine the current arch"
+            )
+        if self.openocd_board == "cortex-m0":
+            raise TockLoaderException(
+                "Could not determine the current openocd board name"
+            )
+        if self.page_size == 0:
+            raise TockLoaderException(
+                "Could not determine the current page size"
             )
 
     def run_terminal(self):


### PR DESCRIPTION
When trying to set up tockloader to use openocd, I kept getting the generic message saying `"Could not determine the current board or arch or openocd board name"`. Not only did it not mention missing `page_size` parameter, but also was too coarse-grained. With splitting the error message, I managed to debug this, so I believe this could be beneficial to anyone.