### PR TITLE
fixing error in get_sequences, index out of range,  checking CRC when writing 0 to flash sector

### DIFF
--- a/tockloader/bootloader_serial.py
+++ b/tockloader/bootloader_serial.py
@@ -1099,7 +1099,8 @@ class BootloaderSerial(BoardInterface):
                         sequences.append((start, last))
                         start = i
                         last = -1
-            sequences.append((start, l[-1] + 1))
+            if start != -1:
+                sequences.append((start, l[-1] + 1))
             return sequences
 
         # Compute the CRC for each stretch of pages in the flashed binary.


### PR DESCRIPTION
Hi!

I got the error:
```
Traceback (most recent call last):
  File "XXX.env/bin/tockloader", line 8, in <module>
    sys.exit(main())
  File "XXX.env/lib/python3.10/site-packages/tockloader/main.py", line 1459, in main
    args.func(args)
  File "XXX.env/lib/python3.10/site-packages/tockloader/main.py", line 300, in command_write
    tock_loader.write_flash(args.address, args.length, args.value)
  File "XXX.env/lib/python3.10/site-packages/tockloader/tockloader.py", line 753, in write_flash
    self.channel.flash_binary(address, to_write, pad=False)
  File "XXX.env/lib/python3.10/site-packages/tockloader/bootloader_serial.py", line 949, in flash_binary
    self._check_crc(address, binary, valid_pages)
  File "XXX.env/lib/python3.10/site-packages/tockloader/bootloader_serial.py", line 1096, in _check_crc
    for start, last in get_sequences(valid_pages):
  File "XXX.env/lib/python3.10/site-packages/tockloader/bootloader_serial.py", line 1091, in get_sequences
    sequences.append((start, l[-1] + 1))
IndexError: list index out of range
```
I can solve it by checking the start value just before the line, trying to check out if the list is empty.
Is it useful?

cheers!

