### PR TITLE
feat: Add OpenTitan Earl Grey ROM_EXT board to KNOWN_BOARDS

### DIFF
--- a/tockloader/board_interface.py
+++ b/tockloader/board_interface.py
@@ -291,6 +291,17 @@ class BoardInterface:
                 "max_size": 0x00100000,
             },
         },
+        "opentitan_earlgrey_rom_ext": {
+            "description": "OpenTitan EarlGrey chip with ROM_EXT targeting the Earlgrey-M2.5.2-RC0 hardware",
+            "arch": "rv32imc",
+            "page_size": 512,
+            "no_attribute_table": True,
+            "address_translator": lambda addr: addr - 0x20010000,
+            "flash_file": {
+                # Set to the maximum flash size.
+                "max_size": 0x00100000,
+            },
+        },
     }
 
     def __init__(self, args):

--- a/tockloader/board_interface.py
+++ b/tockloader/board_interface.py
@@ -291,15 +291,16 @@ class BoardInterface:
                 "max_size": 0x00100000,
             },
         },
-        "opentitan_earlgrey_rom_ext": {
-            "description": "OpenTitan EarlGrey chip with ROM_EXT targeting the Earlgrey-M2.5.2-RC0 hardware",
+        "opentitan_earlgrey_secure_boot": {
+            "description": "OpenTitan EarlGrey chip targeting the Earlgrey-M2.5.2-RC0 hardware with secure boot",
             "arch": "rv32imc",
             "page_size": 512,
             "no_attribute_table": True,
             "address_translator": lambda addr: addr - 0x20010000,
             "flash_file": {
-                # Set to the maximum flash size.
-                "max_size": 0x00100000,
+                # Set to the half of maximum flash size, to keep image sizes smaller
+                # (also ensures room for data at end of flash).
+                "max_size": 0x00070000,
             },
         },
     }


### PR DESCRIPTION
This PR adds a new board, `opentitan_earlgrey_rom_ext`, to `KNOWN_BOARDS` in order to allow Tockloader to load applications in execution environments where OpenTitan uses the [`ROM_EXT`](https://opentitan.org/book/doc/security/specs/secure_boot/#rom_ext) ROM extension boot stage.

`ROM_EXT` is a section in flash occupying addresses `0x20000000` to `0x20010000` which acts as an intermediate boot stage between the actual ROM and any kernel running on OpenTitan. 

By creating a new board in `KNOWN_BOARDS` whose `address_translator` indicates that flash starts at `0x20010000`, we can avoid Tockloader clobbering `ROM_EXT` when loading the kernel and apps, and allow Tockloader to be used with the full boot stack in OpenTitan.

For reverse compatibility with branches of OpenTitan which don't use `ROM_EXT` but do use Tockloader, a new board was added instead of modifying the existing `KNOWN_BOARDS` entry. 