### PR TITLE
add veer_el2_sim board

### DIFF
--- a/tockloader/board_interface.py
+++ b/tockloader/board_interface.py
@@ -162,6 +162,12 @@ class BoardInterface:
                 "max_size": 0x00100000,
             },
         },
+        "veer_el2_sim": {
+            "description": "VeeR EL2 running on Verilated simulation",
+            "arch": "rv32imc",
+            "no_attribute_table": True,
+            "address_translator": lambda addr: addr - 0x20000000,
+        },
         "qemu_rv32_virt": {
             "description": "QEMU RISC-V 32 bit virt Platform",
             "arch": "rv32imac",

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -108,6 +108,7 @@ class TockLoader:
             "hifive1b": {"start_address": 0x20040000},
             "litex_arty": {"start_address": 0x41000000},
             "litex_sim": {"start_address": 0x00080000},
+            "veer_el2_sim": {"start_address": 0x20300000},
             "nrf52dk": {
                 "start_address": 0x40000,
                 "app_ram_address": 0x20008000,


### PR DESCRIPTION
This allows using tockloader to create flash files and install applications for VeeR EL2 (see related PR: https://github.com/tock/tock/pull/4118)