### PR TITLE
JLink: Add serial number argument to specify flashing target

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,12 @@ knowing the device type of the MCU on the board.
 - `speed`: The speed value to pass to JLink. Defaults to 1200.
 - `if`: The interface to pass to JLink.
 
+JLink supports selecting the target board based on the serial number of the
+JTAG. Tockloader exposes this functionality with the `jlink-serial-number`
+flag. 
+
+    tockloader [command] --jlink-serial-number [serial_number]
+
 Tockloader can also do JTAG using OpenOCD. OpenOCD needs to know which config
 file to use.
 

--- a/README.md
+++ b/README.md
@@ -192,19 +192,15 @@ knowing the device type of the MCU on the board.
 
     tockloader [command] --board [board] --arch [arch] --page-size [page_size] \
                          --jlink --jlink-cmd [jlink_cmd] --jlink-device [device] \
-                         --jlink-speed [speed] --jlink-if [if]
+                         --jlink-speed [speed] --jlink-if [if] \
+                         --jlink-serial-number [serial_number]
 
 - `jlink_cmd`: The JLink executable to invoke. Defaults to `JLinkExe` on
   Mac/Linux, and `JLink` on Windows.
 - `device`: The JLinkExe device identifier.
 - `speed`: The speed value to pass to JLink. Defaults to 1200.
 - `if`: The interface to pass to JLink.
-
-JLink supports selecting the target board based on the serial number of the
-JTAG. Tockloader exposes this functionality with the `jlink-serial-number`
-flag. 
-
-    tockloader [command] --jlink-serial-number [serial_number]
+- `serial-number`: The serial number of the target board to use with JLink.
 
 Tockloader can also do JTAG using OpenOCD. OpenOCD needs to know which config
 file to use.

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -779,6 +779,11 @@ def main():
         "--jlink-if", help="The interface type to pass to JLinkExe."
     )
     parent_channel.add_argument(
+        "--jlink-serial-number",
+        default=None,
+        help="Specify a specific JLink via serial number. Useful when multiple JLinks are connected to the same machine.",
+    )
+    parent_channel.add_argument(
         "--openocd-board", help="The cfg file in OpenOCD `board` folder."
     )
     parent_channel.add_argument(


### PR DESCRIPTION
## Overview

Treadmill / CI tests that evaluate networking attach multiple boards to one machine. This PR adds a Tockloader flag (`jlink-serial-no`) to specify the JLink serial number of the device that should be flashed.

This utilizes JLink's command to specify the serial number of the target.