### PR TITLE
feature: add basic support for STM32H7 based Nucleo-144 dev board

### DIFF
--- a/tockloader/board_interface.py
+++ b/tockloader/board_interface.py
@@ -207,6 +207,24 @@ class BoardInterface:
                 "cfg": "st_nucleo_f4.cfg",
             },
         },
+        "nucleoh7cm4": {
+            "description": "STM32H74x_H75x based Nucleo development boards (Cortex M4)",
+            "arch": "cortex-m4",
+            "page_size": 2048,
+            "no_attribute_table": True,
+            "openocd": {
+                "cfg": "st_nucleo_f4.cfg",
+            },
+        },
+        "nucleoh7cm7": {
+            "description": "STM32H74x_H75x based Nucleo development boards (Cortex M7)",
+            "arch": "cortex-m7",
+            "page_size": 2048,
+            "no_attribute_table": True,
+            "openocd": {
+                "cfg": "st_nucleo_f4.cfg",
+            },
+        },
         "hifive1": {
             "description": "SiFive HiFive1 development board",
             "arch": "rv32imac",

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -123,6 +123,8 @@ class TockLoader:
                 "start_address": 0x40000,
             },
             "nucleof4": {"start_address": 0x08040000},
+            "nucleoh7cm4": {"start_address": 0x08100000},       # per STM RM0399 ref. manual (sec. 2.6)
+            "nucleoh7cm7": {"start_address": 0x08000000},
             "microbit_v2": {"start_address": 0x00040000},
             "qemu_rv32_virt": {"start_address": 0x80100000},
             "stm32f3discovery": {"start_address": 0x08020000},


### PR DESCRIPTION
feature: add basic support for STM32H7 based Nucleo-144 dev board

desc: This adds very basic support to tockloader for the Nucleo-144 dev board from ST.