### PR TITLE
Update default.nix to newer nix's and sync version

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -20,7 +20,7 @@ let
     ];
 
     propagatedBuildInputs = with pkgs; [
-      segger-jlink libusb
+      segger-jlink libusb1
     ];
 
     installPhase = ''
@@ -74,7 +74,9 @@ let
   });
 in pkgs.python3Packages.buildPythonPackage rec {
   pname = "tockloader";
-  version = "1.10.0";
+  version = let
+      pattern = "^__version__ = ['\"]([^'\"]*)['\"]\n";
+    in elemAt (match pattern (readFile ./tockloader/_version.py)) 0;
   name = "${pname}-${version}";
 
   propagatedBuildInputs = with python3Packages; [
@@ -87,6 +89,7 @@ in pkgs.python3Packages.buildPythonPackage rec {
     questionary
     pycrypto
     siphash
+    ecdsa
   ] ++ (lib.optional withUnfreePkgs pynrfjprog);
 
   src = ./.;

--- a/tockloader/tickv.py
+++ b/tockloader/tickv.py
@@ -369,7 +369,7 @@ class TicKV:
 
     def _reset(self):
         db_len = len(self.storage_binary)
-        self.storage_binary = bytearray(b"\xFF" * db_len)
+        self.storage_binary = bytearray(b"\xff" * db_len)
 
         # Add the known initialize key, value. I don't know what this key
         # is from, but it is the standard.


### PR DESCRIPTION
This adds the necessary Python dependencies for newer versions of tocklodaer, updates the names of a nix dependency, and parses the Python `_version.py` file to get the package version number, to avoid replicating and stagnation.