### PR TITLE
Bump questionary package version 1.10 to 2.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "six >= 1.9.0",
     "toml >= 0.10.2",
     "tqdm >= 4.45.0 ",
-    "questionary >= 1.10.0"
+    "questionary >= 2.1.1"
 ]
 
 [project.urls]


### PR DESCRIPTION
This update ensures consistency with the allowed Python versions. The questionary package version 1.10 only supports Python up to 3.9.
The latest version, 2.1.1, supports Python 3.8 through 3.12.
In Tockloader, we guarantee that the allowed Python version is 3.9 or higher.
Moreover, I encountered an issue on Python 3.12 when running Tockloader info:

<img width="1786" height="637" alt="image" src="https://github.com/user-attachments/assets/b212abeb-87dd-4507-a8de-55f4fdccf1a8" />

This PR resolves the issue shown in the screenshot.
