### PR TITLE
STM32WLE5JC: Add board configuration

### DIFF
--- a/tockloader/board_interface.py
+++ b/tockloader/board_interface.py
@@ -317,6 +317,17 @@ class BoardInterface:
             "no_attribute_table": True,
             "linkserver": {"device": "LPC55S69"},
         },
+        "stm32wle5jc": {
+            "description": "Seeed Studio LoRa-E5 board based on the STM32WLE5JC SoC",
+            "arch": "cortex-m4",
+            "page_size": 2048,
+            "no_attribute_table": True,
+            "openocd": {
+                "prefix": "source [find interface/stlink.cfg]; \
+                           transport select hla_swd; \
+                           source [find target/stm32wlx.cfg];",
+            },
+        },
     }
 
     def __init__(self, args):

--- a/tockloader/openocd.py
+++ b/tockloader/openocd.py
@@ -248,6 +248,11 @@ You may need to update OpenOCD to the version in latest git master."
                 openocd_cmd=self.openocd_cmd
             )
         )
+        openocd_commands.append(
+            '{openocd_cmd} -c "source [find interface/stlink.cfg]; transport select hla_swd; source [find target/stm32wlx.cfg]; init; exit;"'.format(
+                openocd_cmd=self.openocd_cmd
+            )
+        )
 
         # These are the magic strings in the output of openocd we are looking
         # for. If there is a better way to do this then we should change. But,
@@ -259,6 +264,7 @@ You may need to update OpenOCD to the version in latest git master."
             ("(mfg: 0x049 (Xilinx), part: 0x3631, ver: 0x1)", "arty"),
             ("SWD DPIDR 0x2ba01477", "microbit_v2"),
             ("stm32f4x.cpu", "stm32f4discovery"),
+            ("stm32wlx.cpu", "stm32wle5jc"),
         ]
 
         emulators = []

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -150,6 +150,9 @@ class TockLoader:
             "lpc55s69": {
                 "start_address": 0x20000,
             },
+            "stm32wle5jc": {
+                "start_address": 0x8018000,
+            },
         },
     }
 


### PR DESCRIPTION
## Overview 

This PR adds support for the STM32WLE5JC SoC (found on the Seeed Studio LoRa E5 dev board) via an STLink. This accompanies https://github.com/tock/tock/pull/4695.

## OpenOCD Changes

When initially adding this board, tockloader caused a number of bus faults that arose from attempting to read/write past the end of flash. I am not entirely sure why this has not come up before. My guess is that this has something to do with the lack of an OpenOCD board specific configuration for the stm32wle5jc. OpenOCD only has a target config (different than board config) for the stm32wle5xx (which can be a few different lengths for flash).

Quickly looking, it appears the other boards using OpenOCD have an OpenOCD board specific config (not just a target). Long story short, I  bubbled up errors when attempting to r/w past the end of flash and added some exception handling to gracefully handle when this happens. Someone with a better understanding of OpenOCD/tockloader should sanity check this to make sure these changes are in fact necessary as this impacts all OpenOCD functionality, albeit minor.