### PR TITLE
Add `nrfutil` backend for interacting with nRF devices; fix Nix builds

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,31 +6,6 @@ with builtins;
 let
   inherit (pkgs) stdenv stdenvNoCC lib;
 
-  nrf-command-line-tools = stdenvNoCC.mkDerivation {
-    pname = "nrf-command-line-tools";
-    version = "10.22.1";
-
-    src = builtins.fetchurl {
-      url = "https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/desktop-software/nrf-command-line-tools/sw/versions-10-x-x/10-22-1/nrf-command-line-tools-10.22.1_linux-amd64.tar.gz";
-      sha256 = "sha256:0i3dfhp75rizs7kxyfka166k3zy5hmb28c25377pgnzk6w1yx383";
-    };
-
-    nativeBuildInputs = with pkgs; [
-      autoPatchelfHook
-    ];
-
-    propagatedBuildInputs = with pkgs; [
-      segger-jlink libusb1
-    ];
-
-    installPhase = ''
-      mkdir -p $out/
-      cp -r * $out/
-    '';
-
-    meta.license = lib.licenses.unfree;
-  };
-
   python3Packages = lib.fix' (self: with self; pkgs.python3Packages //
   {
     siphash = buildPythonPackage rec {
@@ -41,65 +16,48 @@ let
         inherit pname version;
         sha256 = "sha256-rul/6V4JoplYGcBYpeSsbZZmGomNf+CtVeO3LJox1GE=";
       };
-    };
 
-    pynrfjprog = buildPythonPackage {
-      pname = "pynrfjprog";
-      version = nrf-command-line-tools.version;
-
-      src = nrf-command-line-tools.src;
-
-      preConfigure = ''
-        cd ./python
-      '';
-
-      format = "pyproject";
-
-      nativeBuildInputs = [
-        setuptools
-        pkgs.autoPatchelfHook
-      ];
-
-      buildInputs = [
-        nrf-command-line-tools
-      ];
-
-      propagatedBuildInputs = [
-        tomli-w
-        future
-      ];
-
-      meta.license = lib.licenses.unfree;
+      pyproject = true;
+      build-system = [ setuptools ];
     };
   });
+
 in pkgs.python3Packages.buildPythonPackage rec {
   pname = "tockloader";
   version = let
       pattern = "^__version__ = ['\"]([^'\"]*)['\"]\n";
-    in elemAt (match pattern (readFile ./tockloader/_version.py)) 0;
-  name = "${pname}-${version}";
-
-  propagatedBuildInputs = with python3Packages; [
-    argcomplete
-    colorama
-    crcmod
-    pyserial
-    toml
-    tqdm
-    questionary
-    pycrypto
-    siphash
-    ecdsa
-  ] ++ (lib.optional withUnfreePkgs pynrfjprog);
+  in elemAt (match pattern (readFile ./tockloader/_version.py)) 0;
 
   src = ./.;
 
-  # Dependency checks require unfree software
-  doCheck = withUnfreePkgs;
+  pyproject = true;
 
-  # Make other dependencies explicitly available as passthru attributes
-  passthru = {
-    inherit nrf-command-line-tools;
-    pynrfjprog = python3Packages.pynrfjprog;
-  };
+  nativeBuildInputs = with python3Packages; [
+    flit
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    appdirs
+    argcomplete
+    colorama
+    crcmod
+    intelhex
+    pycrypto
+    pyserial
+    questionary
+    siphash
+    six
+    toml
+    tqdm
+  ];
+
+  # Ensure that Tockloader can, at runtime, find the `nrfutil` binary:
+  postPatch = lib.optionalString withUnfreePkgs ''
+    substituteInPlace ./tockloader/nrfutil.py \
+      --replace 'shutil.which("nrfutil")' '"${
+        pkgs.nrfutil.withExtensions [
+            "nrfutil-device"
+        ]
+      }/bin/nrfutil"'
+  '';
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,19 @@ dependencies = [
     "argcomplete >= 1.8.2",
     "colorama >= 0.3.7",
     "crcmod >= 1.7",
+    "intelhex >= 2.3.0",
     "pycryptodome >= 3.15.0",
-    "pynrfjprog == 10.19.0",
     "pyserial >= 3.0.1",
     "siphash >= 0.0.1",
     "six >= 1.9.0",
     "toml >= 0.10.2",
     "tqdm >= 4.45.0 ",
     "questionary >= 2.1.1"
+]
+
+[project.optional-dependencies]
+nrfjprog = [
+    "pynrfjprog == 10.19.0",
 ]
 
 [project.urls]

--- a/tockloader/board_interface.py
+++ b/tockloader/board_interface.py
@@ -431,7 +431,8 @@ class BoardInterface:
         """
         return
 
-    def flash_binary(self, address, binary):
+    # TODO: document the `pad` argument
+    def flash_binary(self, address, binary, pad=False):
         """
         Write a binary to the address given.
         """

--- a/tockloader/main.py
+++ b/tockloader/main.py
@@ -858,6 +858,9 @@ def main():
         "--jlink", action="store_true", help="Use JLinkExe to flash."
     )
     parent_channel.add_argument(
+        "--nrfutil", action="store_true", help="Use nrfutil to flash."
+    )
+    parent_channel.add_argument(
         "--openocd", action="store_true", help="Use OpenOCD to flash."
     )
     parent_channel.add_argument(
@@ -891,6 +894,12 @@ def main():
         default=None,
         help="Specify a specific JLink via serial number. Useful when multiple JLinks are connected to the same machine.",
     )
+    parent_channel.add_argument(
+        "--nrfutil-serial-number",
+        default=None,
+        help="Specify a specific board via serial number when using nrfutil. Useful when multiple boards are connected.",
+    )
+    parent_channel.add_argument("--nrfutil-cmd", help="The nrfutil binary to invoke.")
     parent_channel.add_argument(
         "--openocd-serial-number",
         default=None,

--- a/tockloader/nrfjprog.py
+++ b/tockloader/nrfjprog.py
@@ -5,9 +5,6 @@ Interface for boards using nrfjprog.
 import logging
 import struct
 
-import pynrfjprog
-from pynrfjprog import LowLevel, Parameters
-
 from .board_interface import BoardInterface
 from .exceptions import TockLoaderException
 
@@ -18,6 +15,17 @@ class nrfjprog(BoardInterface):
         super().__init__(args)
 
     def open_link_to_board(self):
+        try:
+            import pynrfjprog
+            from pynrfjprog import LowLevel, Parameters
+        except ImportError:
+            raise TockLoaderException(
+                "pynrfjprog Python module not found. Please install it by "
+                + "enabling the `nrfjprog` feature on Tockloader to use this "
+                + "backend (such as by running `pip install"
+                + "tockloader[nrfjprog]`)."
+            )
+
         qspi_size = 0
         self.qspi_address = 0
 

--- a/tockloader/nrfutil.py
+++ b/tockloader/nrfutil.py
@@ -1,0 +1,467 @@
+"""
+Interface for boards using nrfutil.
+"""
+
+import json
+import logging
+import os
+import pprint
+import shutil
+import subprocess
+import tempfile
+import textwrap
+from pathlib import Path
+
+from intelhex import IntelHex
+
+from .board_interface import BoardInterface
+from .exceptions import TockLoaderException
+
+
+class NrfUtil(BoardInterface):
+    def __init__(self, args):
+        super().__init__(args)
+
+        # Indicate that we are not bound to a given device serial number yet:
+        self._opened_board_serial = None
+        self._opened_board_code_page_size = None
+        self._opened_board_vcom0_device = None
+
+    def _ensure_nrfutil_installed(self):
+        # This argument may not be installed on all commands that instantiate
+        # `NrfUtil`. For instance, it is not present when running `tockloader
+        # listen`, which will nonetheless instantiate this object for
+        # discovering the VCOM0 device. Therefore, use `None` as default:
+        self._nrfutil_path = getattr(self.args, "nrfutil_cmd", None)
+
+        # Fallback to discovering nrfutil in PATH:
+        if self._nrfutil_path is None:
+            self._nrfutil_path = shutil.which("nrfutil")
+
+        # Need the `nrfutil` binary to be installed:
+        if not self._nrfutil_path:
+            raise TockLoaderException(
+                "Cannot find nrfutil executable, please install it."
+            )
+
+        # Try executing nrfutil and ensure that it is callable:
+        out = self._run_nrfutil(["--version", "--json"], init=True, as_json=True)
+        info_msg = self._get_nrfutil_json_msg(out, "info")
+        assert info_msg["data"]["name"] == "nrfutil"
+
+        # Ensure that the `device` command is installed:
+        out = self._run_nrfutil(
+            ["device", "--version", "--json"],
+            init=True,
+            as_json=True,
+            custom_error=lambda cmd, output, exception: "It looks like the `nrfutil device` command is not installed. "
+            + "Install it by running `nrfutil install device`.",
+        )
+        info_msg = self._get_nrfutil_json_msg(out, "info")
+        assert info_msg["data"]["name"] == "nrfutil-device"
+
+    def _run_nrfutil(self, args, as_json=False, custom_error=None, init=False):
+        if not init:
+            self._ensure_nrfutil_installed()
+
+        cmd = [self._nrfutil_path] + args
+        logging.debug(
+            "Running: {}".format(
+                " ".join(
+                    map(
+                        lambda arg: (
+                            arg
+                            if type(arg) == str
+                            else arg.decode("utf-8", errors="replace")
+                        ),
+                        cmd,
+                    )
+                )
+            )
+        )
+
+        try:
+            cmd = subprocess.run(cmd, capture_output=True, check=True)
+        except subprocess.CalledProcessError as e:
+            raise TockLoaderException(
+                (
+                    "nrfutil command failed.\n"
+                    + "    Command:\n{}\n"
+                    + "    Stdout:\n{}\n"
+                    + "    Stderr:\n{}"
+                ).format(
+                    " ".join(cmd),
+                    textwrap.indent(
+                        e.stdout.decode("utf-8", errors="replace"), "      > "
+                    ),
+                    textwrap.indent(
+                        e.stderr.decode("utf-8", errors="replace"), "      > "
+                    ),
+                )
+            )
+
+        if as_json:
+            # We expect the output to be lines of valid JSON, where each message
+            # contains at least a "type" key:
+            messages = []
+
+            for line in cmd.stdout.strip().splitlines():
+                try:
+                    msg = json.loads(line)
+                except ValueError:
+                    raise TockLoaderException(
+                        f"nrfutil returned invalid JSON: {line.decode('utf-8')}"
+                    )
+
+                if "type" not in msg:
+                    raise TockLoaderException(
+                        'nrfutil JSON output does not contain "type" key: '
+                        + line.decode("utf-8")
+                    )
+
+                messages.append(msg)
+
+            return messages
+        else:
+            return cmd.stdout
+
+    def _get_nrfutil_json_msg(self, json_messages, message_type):
+        try:
+            msg = next((msg for msg in json_messages if msg["type"] == message_type))
+        except StopIteration:
+            raise TockLoaderException(
+                "nrfutil JSON output did not contain message of type "
+                + f'"{message_type}":\n{pprint.pformat(json_messages)}'
+            )
+        return msg
+
+    def _first_attached_board_serial(self):
+        """
+        Check if an nRF device is attached.
+        """
+        # list devices and check output
+        out = self._run_nrfutil(["device", "list", "--json"], as_json=True)
+        info_msg = self._get_nrfutil_json_msg(out, "info")
+
+        # Sanity check the output:
+        if (
+            "data" not in info_msg
+            or "devices" not in info_msg["data"]
+            or type(info_msg["data"]["devices"]) != list
+        ):
+            raise TockLoaderException(
+                "`nrfutil device list --json` output in unexpected format:\n"
+                + pprint.pformat(info_msg)
+            )
+
+        # If we have at least one device attached, return its serial number:
+        if len(info_msg["data"]["devices"]) > 0:
+            return info_msg["data"]["devices"][0]["serialNumber"]
+
+    def _ensure_board_link_open(self):
+        if self._opened_board_serial is None:
+            raise TockLoaderException(
+                "Cannot perform nrfutil operation without first opening link "
+                + "to board"
+            )
+
+    def nrfutil_installed(self):
+        try:
+            self._ensure_nrfutil_installed()
+            return True
+        except TockLoaderException:
+            return False
+
+    def attached_board_exists(self):
+        return self._first_attached_board_serial() != None
+
+    def open_link_to_board(self):
+        # Refuse if we already have another link "opened":
+        if self._opened_board_serial is not None:
+            raise TockLoaderException(
+                "nrfutil channel already has an open connection to device with "
+                + f"serial number {self._opened_board_serial}"
+            )
+
+        # Try to bind to a given device serial number.
+        #
+        # If one is provided through the `--nrfutil-serial-number` argument, use
+        # that one. We'll make sure that this device is actually attached below,
+        # when trying to determine its VCOM0 device path.
+        #
+        # This argument may not be installed on all commands that instantiate
+        # `NrfUtil`. For instance, it is not present when running `tockloader
+        # listen`, which will nonetheless instantiate this object for
+        # discovering the VCOM0 device. Therefore, use `None` as default:
+        self._opened_board_serial = getattr(self.args, "nrfutil_serial_number", None)
+
+        # Otherwise, fall back to the first attached device:
+        if self._opened_board_serial is None:
+            self._opened_board_serial = self._first_attached_board_serial()
+
+        # If we don't have any devices, throw an error:
+        if self._opened_board_serial is None:
+            raise TockLoaderException("No nRF device attached.")
+
+        # Determine the device's VCOM0 serial port path. Currently, the only way
+        # to get this information through a "list", which we then search for our
+        # board's serial number:
+        out = self._run_nrfutil(["device", "list", "--json"], as_json=True)
+        info_msg = self._get_nrfutil_json_msg(out, "info")
+
+        # Sanity check the output:
+        if (
+            "data" not in info_msg
+            or "devices" not in info_msg["data"]
+            or type(info_msg["data"]["devices"]) != list
+        ):
+            raise TockLoaderException(
+                "`nrfutil device list --json` output in unexpected format:\n"
+                + pprint.pformat(info_msg)
+            )
+
+        # Find our device:
+        try:
+            device = next(
+                (
+                    dev
+                    for dev in info_msg["data"]["devices"]
+                    if dev["serialNumber"] == self._opened_board_serial
+                )
+            )
+        except StopIteration:
+            raise TockLoaderException(
+                "`nrfutil device list --json` did not contain the requested "
+                + f"board with serial {self._opened_board_serial}:\n"
+                + pprint.pformat(info_msg)
+            )
+
+        # Check if we have a VCOM 0 serial port and, if we do, store its
+        # "comName". If this isn't present, we simply return None for queries of
+        # this serial port.
+        if "serialPorts" in device and type(device["serialPorts"]) == list:
+            port = next(
+                filter(lambda sp: sp["vcom"] == 0, device["serialPorts"]),
+                None,
+            )
+            if port is not None:
+                self._opened_board_vcom0_device = port["comName"]
+
+        # We've found a/our target device!
+        logging.info(
+            "Opened nrfutil link to board with serial {}".format(
+                self._opened_board_serial
+            )
+        )
+
+        # If possible, determine the board that is attached. `nrfutil` doesn't
+        # give us an actual devboard name, but if we see a deviceFamily of
+        # "NRF52_FAMILY" and a `jlinkObFirmwareVersion` is set, we assume this
+        # is a `nrf52dk` (which covers both the actual nRF52DK and the
+        # nRF52840DK):
+        out = self._run_nrfutil(
+            [
+                "device",
+                "device-info",
+                "--serial-number",
+                self._opened_board_serial,
+                "--json",
+            ],
+            as_json=True,
+        )
+        info_msg = self._get_nrfutil_json_msg(out, "info")
+
+        # Sanity check the output:
+        if (
+            "data" not in info_msg
+            or "devices" not in info_msg["data"]
+            or type(info_msg["data"]["devices"]) != list
+            or len(info_msg["data"]["devices"]) != 1
+            or "deviceInfo" not in info_msg["data"]["devices"][0]
+        ):
+            raise TockLoaderException(
+                "`nrfutil device core-info --json` output unexpected:\n"
+                + pprint.pformat(info_msg)
+            )
+
+        # Check if we can determine that this is an `nrf52dk`:
+        deviceInfo = info_msg["data"]["devices"][0]["deviceInfo"]
+        if (
+            "jlink" in deviceInfo
+            and "deviceFamily" in deviceInfo["jlink"]
+            and deviceInfo["jlink"]["deviceFamily"] == "NRF52_FAMILY"
+            and "jlinkObFirmwareVersion" in deviceInfo["jlink"]
+        ):
+            logging.info(
+                "Attached to an nRF52DK-series board, configuring from KNOWN_BOARDS"
+            )
+            self.board = "nrf52dk"
+            self._configure_from_known_boards()
+
+            # TODO: at this point, it looks like we should need to load a
+            # chip-specific external memory configuration file to access the SPI
+            # flash. However, at least for the nRF52840DK, this seems to work
+            # out of the box?
+            #
+            # https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-device/guides/programming_external_memory.html
+
+        # Determine the device's code page size, which we use for
+        # read+modify+write cycles when writing flash:
+        out = self._run_nrfutil(
+            [
+                "device",
+                "core-info",
+                "--serial-number",
+                self._opened_board_serial,
+                "--json",
+            ],
+            as_json=True,
+        )
+        info_msg = self._get_nrfutil_json_msg(out, "info")
+
+        # Sanity check the output:
+        if (
+            "data" not in info_msg
+            or "devices" not in info_msg["data"]
+            or type(info_msg["data"]["devices"]) != list
+            or len(info_msg["data"]["devices"]) != 1
+            or "codePageSize" not in info_msg["data"]["devices"][0]
+            or type(info_msg["data"]["devices"][0]["codePageSize"]) != int
+            or info_msg["data"]["devices"][0]["codePageSize"] < 1
+        ):
+            raise TockLoaderException(
+                "`nrfutil device core-info --json` output unexpected:\n"
+                + pprint.pformat(info_msg)
+            )
+
+        # Remember the code page size:
+        self._opened_board_code_page_size = info_msg["data"]["devices"][0][
+            "codePageSize"
+        ]
+
+    def determine_current_board(self):
+        # All this work is already done in `open_link_to_board`:
+        if self._opened_board_serial is None:
+            raise TockLoaderException("Cannot determine current board, no link opened.")
+
+    def vcom0_device(self):
+        return self._opened_board_vcom0_device
+
+    def read_range(self, address, length):
+        """
+        Read using nrfutil.
+        """
+
+        self._ensure_board_link_open()
+
+        # Temporary directory for `nrfutil` to write output into:
+        with tempfile.TemporaryDirectory(
+            prefix="tockloader_nrfutil_", delete=False
+        ) as tmpdir:
+            output_file = Path(tmpdir) / "read.hex"
+
+            # Using 'device memory read' based on online docs
+            self._run_nrfutil(
+                [
+                    "device",
+                    "read",
+                    "--serial-number",
+                    self._opened_board_serial,
+                    "--address",
+                    f"{address:#x}",
+                    "--bytes",
+                    str(length),
+                    # Always perform byte-wise reads. This does not seem to have
+                    # a significant (if any) performance impact in practice, but
+                    # specifying larger values breaks when the address or length
+                    # are not aligned.
+                    "--width",
+                    "8",
+                    "--to-file",
+                    os.fsencode(output_file),
+                ]
+            )
+
+            ih = IntelHex()
+            ih.loadhex(output_file)
+            return bytes(ih.tobinarray())
+
+    # TODO: this method is not well specified, we're just doing what
+    # `nrfjprog` does...
+    def clear_bytes(self, address):
+        """
+        Clear bytes by writing 0xFFs.
+        """
+        logging.debug("Clearing bytes starting at {:#0x}".format(address))
+
+        binary = bytes([0xFF] * 8)
+        self.flash_binary(address, binary)
+
+    def flash_binary(self, address, binary, pad=False):
+        """
+        Write using nrfutil.
+        """
+        # TODO: ignores pad arg!
+
+        self._ensure_board_link_open()
+
+        # NrfUtil does feature the option to only
+        # "ERASE_RANGES_TOUCHED_BY_FIRMWARE", but that only works up to page
+        # granularity. Within a single page we have to perform a
+        # read-modify-write cycle. So, we have to---potentially---extend the
+        # range covered by `address` and `binary` to the next lower and higher
+        # page boundary with contents read from the device:
+        lower_pad_len = address % self._opened_board_code_page_size
+        if lower_pad_len != 0:
+            logging.debug(
+                f"Start address of write ({address:x}) is not aligned to code "
+                + f"flash page size ({self._opened_board_code_page_size}). "
+                + "Performing read-modify-write cycle, reading "
+                + f"{lower_pad_len} bytes at address "
+                + f"{address - lower_pad_len:x}"
+            )
+            address -= lower_pad_len
+            lower_pad_bytes = self.read_range(address, lower_pad_len)
+            binary = lower_pad_bytes + binary
+
+        # Same for the upper bound:
+        upper_pad_len = (
+            self._opened_board_code_page_size
+            - ((address + len(binary)) % self._opened_board_code_page_size)
+        ) % self._opened_board_code_page_size
+        if upper_pad_len != 0:
+            logging.debug(
+                f"End address of write ({address + len(binary):x}) is not "
+                + "aligned to code flash page size "
+                + f"({self._opened_board_code_page_size}). Performing "
+                + f"read-modify-write cycle, reading {upper_pad_len} bytes at "
+                + f"address {address + len(binary):x}"
+            )
+            upper_pad_bytes = self.read_range(address + len(binary), upper_pad_len)
+            binary = binary + upper_pad_bytes
+
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            prefix="tockloader_nrfutil_",
+            suffix=".hex",
+            delete_on_close=False,
+        ) as input_file:
+            # Dump `binary` to a hex file:
+            ih = IntelHex()
+            ih.frombytes(binary, offset=address)
+            ih.write_hex_file(input_file)
+            input_file.close()
+
+            # Now, write this to the board flash:
+            self._run_nrfutil(
+                [
+                    "device",
+                    "program",
+                    "--serial-number",
+                    self._opened_board_serial,
+                    "--firmware",
+                    input_file.name,
+                    "--options",
+                    "chip_erase_mode=ERASE_RANGES_TOUCHED_BY_FIRMWARE",
+                ]
+            )


### PR DESCRIPTION
This adds a Tockloader `BoardInterface` implementation using the `nrfutil` command for interacting with Nordic Semicondutor devices.  This command is intended to replace the deprecated `nrfjprog` library. However, as of this commit, `nrfjprog` remains available in Tockloader and can be installed as an optional dependency using the `nrfjprog` feature.
