### PR TITLE
Force a User-Agent string that is NOT the default Python-urlib.

### DIFF
--- a/tockloader/tab.py
+++ b/tockloader/tab.py
@@ -33,7 +33,11 @@ class TAB:
         else:
             try:
                 # Otherwise download it as a URL.
-                with urllib.request.urlopen(tab_path) as response:
+                request = urllib.request.Request(
+                    tab_path,
+                    headers={"User-Agent": "tockloader"},
+                )
+                with urllib.request.urlopen(request) as response:
                     tmp_file = tempfile.TemporaryFile()
                     # Copy the downloaded response to our temporary file.
                     shutil.copyfileobj(response, tmp_file)


### PR DESCRIPTION
The default user-agent led  to the connection being dropped.

This is especially annoying since the rampup documentation is telling you to download the tab from an URL and then that doesn't work. 

Not sure if there are any other implications here, but at least the demo blink now works to be downloaded. I think this is annoying enough to warrant a release, actually, but your call. 

Credit for the fix goes to Claude, but I was the one wondering what the heck was going on and why the doc instructions were failing. 