### PR TITLE
Add support for nucleo_u545re_q board integration

### DIFF
--- a/tockloader/board_interface.py
+++ b/tockloader/board_interface.py
@@ -317,6 +317,15 @@ class BoardInterface:
             "no_attribute_table": True,
             "linkserver": {"device": "LPC55S69"},
         },
+        "nucleo_u545re_q": {
+            "description": "STM32U545RE-based Nucleo development board",
+            "arch": "cortex-m4",
+            "page_size": 8192,
+            "no_attribute_table": True,
+            "openocd": {
+                "prefix": "source [find interface/stlink.cfg]; source [find target/stm32u5x.cfg];",
+            },
+        },
     }
 
     def __init__(self, args):

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -150,6 +150,10 @@ class TockLoader:
             "lpc55s69": {
                 "start_address": 0x20000,
             },
+            "nucleo_u545re_q": {
+                "start_address": 0x08040000,
+                "cmd_flags": {"openocd": True},
+            },
         },
     }
 


### PR DESCRIPTION
This PR adds support for the nucleo_u545re_q board to Tockloader.

Changes:

Added nucleo_u545re_q to KNOWN_BOARDS in board_interface.py
Added application settings to tockloader.py with a default physical start address of 0x08040000.
Configured OpenOCD prefix to use the stlink.cgf interface and stm32u5x.cfg target (OpenOCD version 0.12+dev minimum).

Testing:
Verified on local hardware using:
   * tockloader info --board nucleo_u545re_q (Success)
   * tockloader install --openocd --board nucleo_u545re_q (Successfully installed blink.tab and c_hello.tab)
   * tockloader list --board nucleo_u545re_q (Success)

