### PR TITLE
tockloader: fix crash reshuffling apps with no kernel present

### DIFF
--- a/tockloader/app_padding.py
+++ b/tockloader/app_padding.py
@@ -73,7 +73,7 @@ class PaddingApp:
         tbfh_binary = self.tbfh.get_binary()
         # Calculate the padding length.
         padding_binary_size = self.get_size() - len(tbfh_binary)
-        return tbfh_binary + b"\xFF" * padding_binary_size
+        return tbfh_binary + b"\xff" * padding_binary_size
 
     def info(self, verbose=False):
         """

--- a/tockloader/tockloader.py
+++ b/tockloader/tockloader.py
@@ -1324,7 +1324,6 @@ class TockLoader:
 
         # Get where app memory might start.
         ram_start_address = self._get_memory_start_address()
-        logging.debug(f"Using RAM start address {ram_start_address:#02x}")
 
         # elf2tab can produce TBFs which have a fixed flash start
         # address, but not a fixed RAM start address, in which case


### PR DESCRIPTION
tl;dr—delete a redundant logging line that crashes in some cases.

---

_reshuffle_apps() logged the RAM start address with a `{:#02x}` format spec before the None-guard that immediately follows it, even though `_get_memory_start_address()` can legitimately return `None` (e.g. an empty flash image, or a TBF with a fixed flash address but no fixed RAM address). That raised:

    TypeError: unsupported format string passed to NoneType.__format__

any time `install`/`update` ran against a board with no kernel written yet (e.g. a freshly registered `local-board` with a zero flash base). The line was also redundant: the very next debug line already prints the same value via the pre-guarded `ram_start_address_hex`, so it is simply removed.


Claude-Session: https://claude.ai/code/session_01KTQ6pWrckM3jp9vfBo4bhk